### PR TITLE
Add: aria-label attribute with value of human-readable timestamp

### DIFF
--- a/main.js
+++ b/main.js
@@ -89,6 +89,7 @@ ODate.prototype.update = function() {
 
 	el.title = ODate.format(date, 'datetime');
 	el.setAttribute('data-o-date-js', '');
+	el.setAttribute('aria-label', ODate.ftTime(date));
 };
 
 function compile(format) {

--- a/main.js
+++ b/main.js
@@ -79,17 +79,19 @@ ODate.prototype.update = function() {
 
 	if (!date) return;
 
+	const dateString = ODate.ftTime(date);
+
 	// To avoid triggering a parent live region unnecessarily
 	// <https://github.com/Financial-Times/o-date/pull/43>
 	if (hasTextNode) {
-		printer.firstChild.nodeValue = ODate.ftTime(date);
+		printer.firstChild.nodeValue = dateString;
 	} else {
-		printer.innerHTML = ODate.ftTime(date);
+		printer.innerHTML = dateString;
 	}
 
 	el.title = ODate.format(date, 'datetime');
 	el.setAttribute('data-o-date-js', '');
-	el.setAttribute('aria-label', ODate.ftTime(date));
+	el.setAttribute('aria-label', dateString);
 };
 
 function compile(format) {


### PR DESCRIPTION
cc @AlbertoElias 

Screen-reader will now read:
`five-hours-ago` instead of `march-one-six-two-zero-one-six-nine-zero-six-am` (i.e. March 16, 2016 9:06am).

N.B. However, will read "25 minutes ago" as `two-five-minutes-ago` and "14 hours ago" as `one-four-hours-ago` - will deal with this separately but feel this is an improvement in the meantime.