### PR TITLE
add use-strict

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 /*global module*/
+'use strict';
 
 const months = '["' + 'January,February,March,April,May,June,July,August,September,October,November,December'.split(',').join('","') + '"]';
 const days = '["' + 'Sunday,Monday,Tuesday,Wednesday,Thursday,Friday,Saturday'.split(',').join('","') + '"]';


### PR DESCRIPTION
Added `'use strict';` so that o-date can be used as a node library without being babel transpiled. Otherwise throws this error on run:
```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```