### PR TITLE
Add new formatting function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Returns relative time or timestamp for a given date, in accordance with FT date 
 
 * `date` A javascript `Date` object or a valid string to pass to the `Date` constructor
 
-### o-date#ftTime(date)
+### o-date#asTodayOrYesterdayOrNothing(date)
 
 Returns ["yesterday"|"today"|""] for a given date. You can request this formatting for `o-date` components by adding `data-o-date-format="today-or-yesterday-or-nothing"`.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Returns a date formatted as a string
      - 'datetime': formats the date in the standard FT long format, including the time e.g. May 15, 2014 8:10 am
      - 'date': formats the date in the standard FT long format e.g. May 15, 2014
      - Any other string using [widespread conventions](http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) for time/date placeholders, which will be replaced with values extracted from the date provided. See './main.js' for an up to date list of supported formats.
-     To avoid e.g. the 'mm' in 'common' being replaced with the month prefix with a double backslash 'co\\mmon' i.e. *In most cases custom date formats should not be used, in favour of the standard FT date and datetime formats'
+     To avoid e.g. the 'mm' in 'common' being replaced with the month prefix with a double backslash 'co\\mmon' i.e. *In most cases custom date formats should not be used, in favour of the standard FT date and datetime formats'*
 
 ### o-date#timeAgo(date)
 
@@ -49,6 +49,12 @@ Returns the relative time since the given date, formatted as a human readable st
 ### o-date#ftTime(date)
 
 Returns relative time or timestamp for a given date, in accordance with FT date formatting conventions.
+
+* `date` A javascript `Date` object or a valid string to pass to the `Date` constructor
+
+### o-date#ftTime(date)
+
+Returns ["yesterday"|"today"|""] for a given date. You can request this formatting for `o-date` components by adding `data-o-date-format="today-or-yesterday-or-nothing"`.
 
 * `date` A javascript `Date` object or a valid string to pass to the `Date` constructor
 

--- a/demos/src/declarative.js
+++ b/demos/src/declarative.js
@@ -1,6 +1,10 @@
 const now = new Date();
 const today = new Date();
+const dates = document.querySelectorAll('time:not([datetime])');
 today.setHours(now.getHours() - 6);
-document.querySelector('time:not([datetime])').setAttribute('datetime', today.toISOString());
+
+for (let i = 0; i < dates.length; i++) {
+  dates[i].setAttribute('datetime', today.toISOString());
+}
 
 require('./demo');

--- a/demos/src/declarative.mustache
+++ b/demos/src/declarative.mustache
@@ -1,3 +1,5 @@
 <time data-o-component="o-date" class="o-date" datetime="2000-06-14T23:00:00.000Z">June 15, 2000</time> (dates far in the past are formatted as exact dates)
 <br>
 <time data-o-component="o-date" class="o-date"></time> (more recent dates are formatted as relative times)
+<br>
+<time data-o-component="o-date" class="o-date" data-o-date-format="today-or-yesterday-or-nothing"></time> (Using the o-date-format option)

--- a/demos/src/imperative.mustache
+++ b/demos/src/imperative.mustache
@@ -1,3 +1,3 @@
 <time data-o-component="o-date" class="o-date"></time><br>
 <time data-o-component="o-date" class="o-date"></time><br>
-<time data-o-component="o-date" class="o-date"></time>
+<time data-o-component="o-date" data-o-date-format="today-or-yesterday-or-nothing" class="o-date"></time><br>

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -132,6 +132,19 @@ describe('date', function() {
 		expect(oDate.format(date, 'HH')).to.be('23');
 
 	});
+	it('returns today for today, yestereday for yesterday, nothing for further back', function() {
+		const today = new Date(new Date().getTime() - 10000);
+		const yesterday = new Date(new Date().getTime() - (1000 * 60 * 60 * 24));
+		const aboutToHappen = new Date(new Date().getTime() + 60000);
+		const future = new Date(new Date().getTime() + (20000));
+		const tomorrow = new Date(new Date().getTime() + (1000 * 60 * 60 * 24));
+		const dayBeforeYesterday = new Date(new Date().getTime() - (1000 * 60 * 60 * 48));
+
+		expect(oDate.asTodayOrYesterdayOrNothing(today)).to.be('today');
+		expect(oDate.asTodayOrYesterdayOrNothing(yesterday)).to.be('yesterday');
+		expect(oDate.asTodayOrYesterdayOrNothing(aboutToHappen)).to.be('today');
+		expect(oDate.asTodayOrYesterdayOrNothing(future)).to.be('today');
+		expect(oDate.asTodayOrYesterdayOrNothing(tomorrow)).to.be('');
+		expect(oDate.asTodayOrYesterdayOrNothing(dayBeforeYesterday)).to.be('');
+	});
 });
-
-


### PR DESCRIPTION
Next have a need for a formatting option that displays the most appropriate of:
{today|yesterday|''}

This commit adds a formatting function which can be invoked by adding the
`data-o-date-format=today-or-yesterday-or-nothing` data attribute to a date.

This way of solving this problem demonstrates a way to add further formatting
helpers should we need them.

This commit:
- Adds the helper, ODate.asTodayOrYesterdayOrNothing
- Adds some tests for ODate.asTodayOrYesterdayOrNothing
- Updates the demos with this option
- Adds a dependency to jasmine core so tests will run

@AlbertoElias what do you think about this as a general approach?