### PR TITLE
add date only formatting option

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,7 +95,7 @@ ODate.prototype.update = function() {
 
 	if (format === 'today-or-yesterday-or-nothing') {
 		 dateString = ODate.asTodayOrYesterdayOrNothing(date);
-	} else if (format === 'date') {
+	} else if (format === 'date-only') {
 		dateString = ODate.format(date, 'date');
 	} else {
 		 dateString = ODate.ftTime(date);

--- a/main.js
+++ b/main.js
@@ -95,6 +95,8 @@ ODate.prototype.update = function() {
 
 	if (format === 'today-or-yesterday-or-nothing') {
 		 dateString = ODate.asTodayOrYesterdayOrNothing(date);
+	} else if (format === 'date') {
+		dateString = ODate.format(date, 'date');
 	} else {
 		 dateString = ODate.ftTime(date);
 	}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/733849/16684458/11fa4214-44fd-11e6-94b7-0a34110ff5e6.png)

adding capability to specify that we want the date, that is, instead of "today", use today's date, "yesterday", use yesterday's date, and before that, the same behaviour.

This test is relevant: https://github.com/Financial-Times/o-date/blob/master/test/date.test.js#L22