### PR TITLE
Refactor for testing

### DIFF
--- a/main.js
+++ b/main.js
@@ -134,7 +134,7 @@ ODate.toDate = function(date) {
 	if (date.toString() !== 'Invalid Date') {
 		return date;
 	}
-}
+};
 
 ODate.format = function(date, dateFormat) {
 	dateFormat = dateFormat || 'datetime';
@@ -145,7 +145,7 @@ ODate.format = function(date, dateFormat) {
 
 ODate.getSecondsBetween = function(time, otherTime) {
 	return Math.round((time - otherTime) / 1000);
-}
+};
 
 ODate.ftTime = function(dateObj) {
 	const now = new Date();
@@ -169,7 +169,7 @@ ODate.ftTime = function(dateObj) {
 	}
 
 	return dateString;
-}
+};
 
 ODate.isNearFuture = function(interval) {
 	// If the interval within the next 5 minutes
@@ -179,19 +179,19 @@ ODate.isNearFuture = function(interval) {
 ODate.isFarFuture = function(interval) {
 	// If the interval is further in the future than 5 minutes
 	return interval < -(5 * inSeconds.minute);
-}
+};
 
 ODate.isToday = function(date, now, interval) {
 	const within24Hours = interval < inSeconds.day;
 	const sameDayOfWeek = now.getDay() === date.getDay();
 	return (within24Hours && sameDayOfWeek);
-}
+};
 
 ODate.isYesterday = function(date, now, interval) {
 	const within48Hours = interval < 2 * inSeconds.day;
 	const consecutiveDaysOfTheWeek = now.getDay() === date.getDay()+1;
 	return (within48Hours && consecutiveDaysOfTheWeek);
-}
+};
 
 ODate.timeAgo = function(date, interval) {
 

--- a/main.js
+++ b/main.js
@@ -152,18 +152,25 @@ ODate.ftTime = function(dateObj) {
 	const interval = ODate.getSecondsBetween(now, dateObj);
 	let dateString;
 
+	// If the date will occur in the next 5 minutes. This check is to allow for
+	// reasonably differences in machine clocks.
 	if (ODate.isNearFuture(interval)) {
 		dateString = 'just now';
 
+	// If it's beyond 5 minutes, fall back to printing the whole date, the machine
+	// clock could be way out.
 	} else if (ODate.isFarFuture(interval)) {
 		dateString = ODate.format(dateObj, 'date');
 
+	// Relative times for today
 	} else if (ODate.isToday(dateObj, now, interval)) {
 		dateString = ODate.timeAgo(dateObj, now, interval);
 
+	// 'Yesterday' for dates that occurred yesterday
 	} else if (ODate.isYesterday(dateObj, now, interval)) {
 		dateString = 'yesterday';
 
+	// Else print the date
 	} else {
 		dateString = ODate.format(dateObj, 'date');
 	}

--- a/main.js
+++ b/main.js
@@ -181,14 +181,16 @@ ODate.isFarFuture = function(interval) {
 	return interval < -(5 * inSeconds.minute);
 }
 
-ODate.isToday = function(dateObj, now, interval) {
-	// If the interval is within the 24 hours and the same day
-	return (interval < inSeconds.day && now.getDay() === date.getDay());
+ODate.isToday = function(date, now, interval) {
+	const within24Hours = interval < inSeconds.day;
+	const sameDayOfWeek = now.getDay() === date.getDay();
+	return (within24Hours && sameDayOfWeek);
 }
 
-ODate.isYesterday = function(dateObj, now, interval) {
-	// If the interval is within the last 48 hours and 1 day less
-	return (interval < 2 * inSeconds.day && now.getDay() === date.getDay() - 1);
+ODate.isYesterday = function(date, now, interval) {
+	const within48Hours = interval < 2 * inSeconds.day;
+	const consecutiveDaysOfTheWeek = now.getDay() === date.getDay()+1;
+	return (within48Hours && consecutiveDaysOfTheWeek);
 }
 
 ODate.timeAgo = function(date, interval) {
@@ -227,14 +229,14 @@ ODate.asTodayOrYesterdayOrNothing = function(date){
 	if (!date) return;
 
 	const now = new Date();
-	const interval = Math.round((now - date) / 1000); // Time since `date` in seconds
+	const interval = ODate.getSecondsBetween(now, date);
 
 	let dateString;
 
 	// If this was less than a day ago
-	if (interval < inSeconds.day && now.getDay() === date.getDay()) {
+	if (ODate.isToday(date, now, interval)) {
 		dateString = 'today';
-	} else if (interval < (inSeconds.day * 2) && (now.getDay() === date.getDay() + 1)) {
+	} else if (ODate.isYesterday(date, now, interval)) {
 		dateString = 'yesterday';
 	} else {
 		dateString = '';

--- a/main.js
+++ b/main.js
@@ -83,7 +83,7 @@ ODate.prototype.update = function() {
 	const hasTextNode = printer.firstChild && printer.firstChild.nodeType === 3;
 
 	if (date) {
-		date = toDate(date);
+		date = ODate.toDate(date);
 	} else if (hasTextNode) {
 		// Only define new date if printer is empty
 		date = new Date();
@@ -129,7 +129,7 @@ function compile(format) {
 	return (compiledTemplates[format] = new Function('date', funcString));  // jshint ignore:line
 }
 
-function toDate(date) {
+ODate.toDate = function(date) {
 	date = date instanceof Date ? date : new Date(date);
 	if (date.toString() !== 'Invalid Date') {
 		return date;
@@ -139,13 +139,17 @@ function toDate(date) {
 ODate.format = function(date, dateFormat) {
 	dateFormat = dateFormat || 'datetime';
 	const tpl = compiledTemplates[dateFormat] || compile(dateFormat);
-	date = toDate(date);
+	date = ODate.toDate(date);
 	return date && tpl(date);
 };
 
+ODate.getIntervalBetween = function(now, dateObject) {
+	return Math.round((now - dateObject) / 1000);
+}
+
 ODate.ftTime = function(dateObj) {
 	const now = new Date();
-	const interval = Math.round((now - dateObj) / 1000);
+	const interval = ODate.getIntervalBetween(now, dateObj);
 	let dateString;
 
 	// if date has not yet passed
@@ -172,7 +176,7 @@ ODate.ftTime = function(dateObj) {
 
 ODate.timeAgo = function(date, interval) {
 
-	date = toDate(date);
+	date = ODate.toDate(date);
 	if (!date) return;
 
 	interval = interval || Math.round(((new Date()) - date) / 1000);


### PR DESCRIPTION
This PR refactors some parts of o-date's main.js so that (in a later PR) the tests can be rewritten to be more readable, and provide better coverage.

This commit: moves some repeated logic into separate public testable functions: 
`isYesterday(date, date, interval)`, `isToday(date, date, interval)`, `isNearFuture(interval)` and `isFarFuture(interval)` and `getSecondsBetween(time, othertime)`.

Making these public means we can write tests for these individual functions rather than having to write a lot of logic in a single test to test things like ftTime properly. Happy to bikeshed on the names / behaviours of some of these functions, particularly isNearFuture and isFarFuture which i think could be improved.

Following this being merged (and still passing the old tests) I'll open a new pr with the new tests.