### PR TITLE
Fix yesterday

### DIFF
--- a/main.js
+++ b/main.js
@@ -94,7 +94,7 @@ ODate.prototype.update = function() {
 	let dateString;
 
 	if (format === 'today-or-yesterday-or-nothing') {
-		 dateString = ODate.asTodayOrYesterdayOrNothing(date);
+		dateString = ODate.asTodayOrYesterdayOrNothing(date);
 	} else if (format === 'date-only') {
 		dateString = ODate.format(date, 'date');
 	} else {

--- a/main.js
+++ b/main.js
@@ -164,8 +164,8 @@ ODate.ftTime = function(dateObj) {
 	} else if (ODate.isFarFuture(interval)) {
 		dateString = ODate.format(dateObj, 'date');
 
-	// Relative times for today
-	} else if (ODate.isToday(dateObj, now, interval)) {
+	// Relative times for today or within the last 4 hours
+	} else if (ODate.isToday(dateObj, now, interval) || (interval < (4 * inSeconds.hour))) {
 		dateString = ODate.timeAgo(dateObj, now, interval);
 
 	// 'Yesterday' for dates that occurred yesterday

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -171,7 +171,7 @@ describe('o-date', () => {
 					new Date("Jul 13 2016 22:02:49"),
 					new Date("Jul 13 2016 21:02:49"),
 					new Date("Jul 13 2016 20:02:50")
-				]
+				];
 
 			let fakeNow = new Date("Jul 14 2016 00:02:49");
 			jasmine.clock().mockDate(fakeNow);
@@ -194,7 +194,7 @@ describe('o-date', () => {
 					new Date("Jul 13 2016 18:02:49"),
 					new Date("Jul 13 2016 17:02:49"),
 					new Date("Jul 13 2016 00:02:50")
-				]
+				];
 
 			let fakeNow = new Date("Jul 14 2016 00:02:49");
 			jasmine.clock().mockDate(fakeNow);

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -166,14 +166,14 @@ describe('o-date', () => {
 			const oDateTimeAgoReturn = "mocked timeAgo date";
 			spyOn(oDate, 'timeAgo').and.returnValue(oDateTimeAgoReturn);
 
-			let publishDatesInTheLast4Hours =
-				[ new Date("Jul 13 2016 23:02:49"),
-					new Date("Jul 13 2016 22:02:49"),
-					new Date("Jul 13 2016 21:02:49"),
-					new Date("Jul 13 2016 20:02:50")
-				];
+			const publishDatesInTheLast4Hours = [
+				new Date("Jul 13 2016 23:02:49"),
+				new Date("Jul 13 2016 22:02:49"),
+				new Date("Jul 13 2016 21:02:49"),
+				new Date("Jul 13 2016 20:02:50")
+			];
 
-			let fakeNow = new Date("Jul 14 2016 00:02:49");
+			const fakeNow = new Date("Jul 14 2016 00:02:49");
 			jasmine.clock().mockDate(fakeNow);
 			for (let date of publishDatesInTheLast4Hours) {
 				expect(oDate.ftTime(date)).toBe(oDateTimeAgoReturn);
@@ -189,14 +189,14 @@ describe('o-date', () => {
 			spyOn(oDate, 'isFarFuture').and.returnValue(false);
 			spyOn(oDate, 'isToday').and.returnValue(false);
 
-			let publishDatesInTheLast4Hours =
-				[ new Date("Jul 13 2016 19:02:49"),
-					new Date("Jul 13 2016 18:02:49"),
-					new Date("Jul 13 2016 17:02:49"),
-					new Date("Jul 13 2016 00:02:50")
-				];
+			const publishDatesInTheLast4Hours = [
+				new Date("Jul 13 2016 19:02:49"),
+				new Date("Jul 13 2016 18:02:49"),
+				new Date("Jul 13 2016 17:02:49"),
+				new Date("Jul 13 2016 00:02:50")
+			];
 
-			let fakeNow = new Date("Jul 14 2016 00:02:49");
+			const fakeNow = new Date("Jul 14 2016 00:02:49");
 			jasmine.clock().mockDate(fakeNow);
 			for (let date of publishDatesInTheLast4Hours) {
 				expect(oDate.ftTime(date)).not.toBe(oDateTimeAgoReturn);

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -122,7 +122,6 @@ describe('o-date', () => {
 	describe('ODate.ftTime', () => {
 
 		const someDate = new Date("Jul 13 2016 00:02:00");
-
 		beforeEach(() => {
 			jasmine.clock().install();
 		});
@@ -152,15 +151,57 @@ describe('o-date', () => {
 		});
 
 		it('returns a result from ODate.timeAgo if ODate.isToday returns true', () => {
-			const oDateFormatReturn = "mocked timeAgo date";
+			const oDateTimeAgoReturn = "mocked timeAgo date";
 			spyOn(oDate, 'isNearFuture').and.returnValue(false);
 			spyOn(oDate, 'isFarFuture').and.returnValue(false);
 			spyOn(oDate, 'isToday').and.returnValue(true);
 
-			spyOn(oDate, 'timeAgo').and.returnValue(oDateFormatReturn);
+			spyOn(oDate, 'timeAgo').and.returnValue(oDateTimeAgoReturn);
 
-			expect(oDate.ftTime(someDate)).toBe(oDateFormatReturn);
+			expect(oDate.ftTime(someDate)).toBe(oDateTimeAgoReturn);
 			expect(oDate.timeAgo).toHaveBeenCalledWith(someDate, jasmine.any(Date), jasmine.any(Number));
+		});
+
+		it('returns a result from timeAgo if the publish date is less than 4 hours ago even if that date is also yesterday', ()=>{
+			const oDateTimeAgoReturn = "mocked timeAgo date";
+			spyOn(oDate, 'timeAgo').and.returnValue(oDateTimeAgoReturn);
+
+			let publishDatesInTheLast4Hours =
+				[ new Date("Jul 13 2016 23:02:49"),
+					new Date("Jul 13 2016 22:02:49"),
+					new Date("Jul 13 2016 21:02:49"),
+					new Date("Jul 13 2016 20:02:50")
+				]
+
+			let fakeNow = new Date("Jul 14 2016 00:02:49");
+			jasmine.clock().mockDate(fakeNow);
+			for (let date of publishDatesInTheLast4Hours) {
+				expect(oDate.ftTime(date)).toBe(oDateTimeAgoReturn);
+				expect(oDate.timeAgo).toHaveBeenCalledWith(date, jasmine.any(Date), jasmine.any(Number));
+			}
+		});
+
+		it('doesnt return a result from timeAgo if the publish date is more than 4 hours ago and isToday is false', ()=>{
+			const oDateTimeAgoReturn = "mocked timeAgo date";
+			spyOn(oDate, 'timeAgo').and.returnValue(oDateTimeAgoReturn);
+
+			spyOn(oDate, 'isNearFuture').and.returnValue(false);
+			spyOn(oDate, 'isFarFuture').and.returnValue(false);
+			spyOn(oDate, 'isToday').and.returnValue(false);
+
+			let publishDatesInTheLast4Hours =
+				[ new Date("Jul 13 2016 19:02:49"),
+					new Date("Jul 13 2016 18:02:49"),
+					new Date("Jul 13 2016 17:02:49"),
+					new Date("Jul 13 2016 00:02:50")
+				]
+
+			let fakeNow = new Date("Jul 14 2016 00:02:49");
+			jasmine.clock().mockDate(fakeNow);
+			for (let date of publishDatesInTheLast4Hours) {
+				expect(oDate.ftTime(date)).not.toBe(oDateTimeAgoReturn);
+				expect(oDate.timeAgo).not.toHaveBeenCalledWith(date, jasmine.any(Date), jasmine.any(Number));
+			}
 		});
 
 		it('returns a result from "yesterday" if ODate.isYesterday returns true', () => {


### PR DESCRIPTION
Currently the date is only displayed in a TimeAgo format if the publish date was
sometime today and in the past.
This leads to things like stories being published at 23:55 displaying as 'yesterday'
even if viewed only 10 minutes later.

This commit changes the behaviour to always show timeAgo() if the publish date
was within the last 4 hours, regardless of the date. After that the date will be
displayed as timeAgo() if the publish date was today, or 'yesterday' if the publish
date was yesterday and more than 4 hours ago.

This would fix #55 