### PR TITLE
Adds abbreviation option to time ago method

### DIFF
--- a/main.js
+++ b/main.js
@@ -97,8 +97,10 @@ ODate.prototype.update = function() {
 		dateString = ODate.asTodayOrYesterdayOrNothing(date);
 	} else if (format === 'date-only') {
 		dateString = ODate.format(date, 'date');
-	} else if (format === 'time-ago-limit-4-hours'){
+	} else if (format === 'time-ago-limit-4-hours') {
 		dateString = ODate.timeAgo(date, { limit: 4*inSeconds.hour });
+	} else if (format === 'time-ago-abbreviated-limit-4-hours') {
+		dateString = ODate.timeAgo(date, { abbreviated: true, limit: 4*inSeconds.hour });
 	} else if (format !== null) {
 		dateString = ODate.format(date, format);
 	} else {
@@ -227,28 +229,30 @@ ODate.timeAgo = function(date, interval, options) {
 		return '';
 	}
 
+	const abbreviated = options ? options.abbreviated : false;	
+
 	if (interval < inSeconds.minute) {
-		return interval + ' seconds ago';
+		return `${abbreviated ? interval + 's' : interval + ' seconds'} ago`;
 	} else if (interval < (1.5 * inSeconds.minute)) {
-		return 'a minute ago';
+		return `${abbreviated ? '1m' : 'a minute'} ago`;
 	} else if (interval < (59 * inSeconds.minute) ) {
-		return Math.round(interval / inSeconds.minute) + ' minutes ago';
+		return `${Math.round(interval / inSeconds.minute)}${abbreviated ? 'm' : ' minutes'} ago`;
 	} else if (interval < (1.5 * inSeconds.hour)) {
-		return 'an hour ago';
+		return `${abbreviated ? '1h' : 'an hour'} ago`;
 	} else if (interval < 22 * inSeconds.hour) {
-		return Math.round(interval / inSeconds.hour) + ' hours ago';
+		return `${Math.round(interval / inSeconds.hour)}${abbreviated ? 'h' : ' hours'} ago`;
 	} else if (interval < (1.5 * inSeconds.day)) {
-		return 'a day ago';
+		return `${abbreviated ? '1d' : 'a day'} ago`;
 	} else if (interval < 25 * inSeconds.day) {
-		return Math.round(interval / inSeconds.day) + ' days ago';
+		return `${Math.round(interval / inSeconds.day)}${abbreviated ? 'd' : ' days'} ago`;
 	} else if (interval < (45 * inSeconds.day)) {
-		return 'a month ago';
+		return `${abbreviated ? '1mth' : 'a month'} ago`;
 	} else if (interval < 345 * inSeconds.day) {
-		return Math.round(interval / inSeconds.month) + ' months ago';
+		return `${Math.round(interval / inSeconds.month)}${abbreviated ? 'mth' : ' months'} ago`;
 	} else if (interval < (547 * inSeconds.day)) {
-		return 'a year ago';
+		return `${abbreviated ? '1y' : 'a year'} ago`;
 	} else {
-		return Math.max(2, Math.floor(interval / inSeconds.year)) + ' years ago';
+		return `${ Math.max(2, Math.floor(interval / inSeconds.year))}${abbreviated ? 'y' : ' years'} ago`;
 	}
 };
 

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -425,6 +425,28 @@ describe('o-date', () => {
 				expect(oDate.timeAgo(publishDate, 5)).toBe('5 seconds ago');
 			}
 		});
+		
+		it('returns abbreviations if the abbreviated option is provided', () => {
+			const abbreviations = {
+				'2s ago': 2 * inSeconds.second,
+				'1m ago': inSeconds.minute,
+				'2m ago': 90 * inSeconds.second,
+				'1h ago': inSeconds.hour,
+				'2h ago': 90 * inSeconds.minute,
+				'1d ago': 22 * inSeconds.hour,
+				'2d ago': 36 * inSeconds.hour,
+				'1mth ago': 25 * inSeconds.day,
+				'2mth ago': 45 * inSeconds.day,
+				'1y ago': 345 * inSeconds.day,
+				'2y ago': 547 * inSeconds.day
+			};
+			
+			Object.keys(abbreviations).forEach(function (abbreviation) {
+				let date = new Date();
+				date = date - (abbreviations[abbreviation] * 1000);
+				expect(oDate.timeAgo(date, { abbreviated: true })).toBe(abbreviation);
+			});
+		});
 	});
 
 	describe('ODate.asTodayOrYesterdayOrNothing', () => {


### PR DESCRIPTION
This feature has been requested for the new layout of FastFT on the
homepage.

<img width="1229" alt="screen shot 2016-11-10 at 12 26 25" src="https://cloud.githubusercontent.com/assets/524573/20176715/f29f9710-a740-11e6-9f48-964bc6aaaf1c.png">


Units will be abbreviated to the following:

Seconds = s
Minutes = m
Hours = h
Days = d
Months = mth
Years = y

I would appreciate feedback from the origami devs regarding the
abbreviation of months. The use of `mth` feels clunky and we are unsure
if the users would understand what it stands for.

In fastFT we will be using the 4 hour limit so days, months and years
will never be used. If the abbreviated option exists we could exit
earlier in the same way [limit does](https://github.com/Financial-Times/o-date/blob/master/main.js#L226) but that would result in the abbreviated option 
having its own behaviour of to limit < months.

I wasn't sure on doing this as the limit option already exists so I felt
like this should be set when the function is called rather than by the
presents of the abbreviated option. That leaves us however in this
scenario where we are not sure what to do with months if someone doesn't
set a limit.