### PR TITLE
adds timeAgoNoSeconds

### DIFF
--- a/main.js
+++ b/main.js
@@ -101,10 +101,12 @@ ODate.prototype.update = function() {
 		dateString = ODate.timeAgo(date, { limit: 4*inSeconds.hour });
 	} else if (format === 'time-ago-abbreviated-limit-4-hours') {
 		dateString = ODate.timeAgo(date, { abbreviated: true, limit: 4*inSeconds.hour });
+	} else if (format === 'time-ago-no-seconds') {
+		dateString = ODate.timeAgoNoSeconds(date);
 	} else if (format !== null) {
 		dateString = ODate.format(date, format);
 	} else {
-		 dateString = ODate.ftTime(date);
+		dateString = ODate.ftTime(date);
 	}
 
 	// To avoid triggering a parent live region unnecessarily
@@ -229,7 +231,7 @@ ODate.timeAgo = function(date, interval, options) {
 		return '';
 	}
 
-	const abbreviated = options ? options.abbreviated : false;	
+	const abbreviated = options ? options.abbreviated : false;
 
 	if (interval < inSeconds.minute) {
 		return `${abbreviated ? interval + 's' : interval + ' seconds'} ago`;
@@ -275,6 +277,20 @@ ODate.asTodayOrYesterdayOrNothing = function(date){
 	}
 
 	return dateString;
+};
+
+ODate.timeAgoNoSeconds = function(date){
+
+	if (!date) return;
+
+	const now = new Date();
+	const interval = ODate.getSecondsBetween(now, date);
+
+	// If this was less than a minute ago
+	if (interval < 60) {
+		return 'Less than a minute ago';
+	}
+	return ODate.timeAgo(date);
 };
 
 ODate.init = function(el) {

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -499,16 +499,16 @@ describe('o-date', () => {
 
 	describe('ODate.timeAgoNoSeconds', () => {
 		it('returns \'Less than a minute ago\' if time was less than a minute ago', () => {
-			let date
-			date = new Date() - (2 * inSeconds.second * 1000) // 1 second ago
+			let date;
+			date = new Date() - (2 * inSeconds.second * 1000); // 1 second ago
 			expect(oDate.timeAgoNoSeconds(date)).toBe('Less than a minute ago');
 
-			date = new Date() - (59 * inSeconds.second * 1000) // 59 seconds ago
+			date = new Date() - (59 * inSeconds.second * 1000); // 59 seconds ago
 			expect(oDate.timeAgoNoSeconds(date)).toBe('Less than a minute ago');
 
-			date = new Date() - (60 * inSeconds.second * 1000) // 1 minute ago
+			date = new Date() - (60 * inSeconds.second * 1000); // 1 minute ago
 			spyOn(oDate, 'timeAgo');
-			oDate.timeAgoNoSeconds(date)
+			oDate.timeAgoNoSeconds(date);
 			expect(expect(oDate.timeAgo).toHaveBeenCalledWith(date));
 		});
 	});

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -425,7 +425,7 @@ describe('o-date', () => {
 				expect(oDate.timeAgo(publishDate, 5)).toBe('5 seconds ago');
 			}
 		});
-		
+
 		it('returns abbreviations if the abbreviated option is provided', () => {
 			const abbreviations = {
 				'2s ago': 2 * inSeconds.second,
@@ -440,7 +440,7 @@ describe('o-date', () => {
 				'1y ago': 345 * inSeconds.day,
 				'2y ago': 547 * inSeconds.day
 			};
-			
+
 			Object.keys(abbreviations).forEach(function (abbreviation) {
 				let date = new Date();
 				date = date - (abbreviations[abbreviation] * 1000);
@@ -494,6 +494,22 @@ describe('o-date', () => {
 
 			expect(oDate.isToday).toHaveBeenCalledWith(mockDate, jasmine.any(Date), jasmine.any(Number));
 			expect(oDate.isYesterday).toHaveBeenCalledWith(mockDate, jasmine.any(Date), jasmine.any(Number));
+		});
+	});
+
+	describe('ODate.timeAgoNoSeconds', () => {
+		it('returns \'Less than a minute ago\' if time was less than a minute ago', () => {
+			let date
+			date = new Date() - (2 * inSeconds.second * 1000) // 1 second ago
+			expect(oDate.timeAgoNoSeconds(date)).toBe('Less than a minute ago');
+
+			date = new Date() - (59 * inSeconds.second * 1000) // 59 seconds ago
+			expect(oDate.timeAgoNoSeconds(date)).toBe('Less than a minute ago');
+
+			date = new Date() - (60 * inSeconds.second * 1000) // 1 minute ago
+			spyOn(oDate, 'timeAgo');
+			oDate.timeAgoNoSeconds(date)
+			expect(expect(oDate.timeAgo).toHaveBeenCalledWith(date));
 		});
 	});
 });


### PR DESCRIPTION

![doge](https://cloud.githubusercontent.com/assets/11544418/21162168/e4fb2914-c183-11e6-8242-577bce49b0b5.jpeg)

This adds a new format that will return `'Less than a minute ago'` for times that are, you guessed it, less than a minute ago. 🕐 

<img width="200" src="http://www.lovethisgif.com/uploaded_images/63457-Clock-Animation-Exactly-One-Minute-.gif">

--------------
Also inadvertently removed some trailing whitespaces 🙌 

<img width="300" alt="dusting" src="http://stream1.gifsoup.com/view2/20141125/5141782/snow-white-dusting-o.gif">

--------

Wow! GIF-tastic PR right! 🎉 

<img width="300" alt="gif party" src="https://media.giphy.com/media/xT9DPPDcGu4kX42LqE/giphy.gif">

Ok I'll stop now 😔 