### PR TITLE
Align the module with new Origami standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-.sass-cache
-node_modules
-demos/local
-build/
-demos/*.html
+.DS_Store
+.env
+.idea/
+/.sass-cache/
+/bower_components/
+/build/
+/demos/local
+/node_modules/
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -2,24 +2,35 @@
 
 o-date provides javascript utilities for formatting and updating dates in FT style. This component is mainly useful when you want your dates formatted to express relative time.
 
-## Browser support
+  - [Usage](#usage)
+    - [Browser support](#browser-support)
+    - [Markup](#markup)
+    - [JavaScript](#javascript)
+  - [Contact](#contact)
+  - [Licence](#licence)
+
+## Usage
+
+### Browser support
 
 This module has been verified in Internet Explorer 8+, modern desktop browsers (Chrome, Safari, Firefox, ...) and mobile browsers (Android browser, iOS safari, Chrome mobile).
 
-## Core experience
+### Markup
 
-To provide the best non-js fallback you should markup your dates as follows
+To provide the best non-JS fallback you should markup your dates as follows:
 
-    <time data-o-component="o-date" class="o-date" datetime="{{iso8601String}}">{FT formatted date (including time if appropriate)}</time>
+```html
+<time data-o-component="o-date" class="o-date" datetime="{{iso8601String}}">{FT formatted date (including time if appropriate)}</time>
+```
 
-This module's `format` method will also run in node and can be used to populate your model with the appropriate formatted date string. It's not recommended to output the 'time ago' server side as it will not be cacheable and will not update in the browser if the user leaves the page open for a prolonged period of time.
+This module's `format` method will also run in Node.js and can be used to populate your model with the appropriate formatted date string. It's not recommended to output the 'time ago' server side as it will not be cacheable and will not update in the browser if the user leaves the page open for a prolonged period of time.
 
-## Enhanced experience
+### JavaScript
 
 To display dates in the standard relative time format, a `o.DOMContentLoaded` event can be dispatched on the `document` to auto-construct each element with a `data-o-component="o-date"` attribute:
 
-```javascript
-document.addEventListener("DOMContentLoaded", function() {
+```js
+document.addEventListener('DOMContentLoaded', function() {
     document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });
 ```
@@ -28,38 +39,46 @@ You can also run `require('o-date').init()` once the DOM has loaded if you don't
 
 Run `require('o-date').init(el)` on any elements containing dates that are added to the page after DOM load.
 
-## API
-
-### o-date#format(date, tpl)
+#### o-date#format(date, tpl)
 
 Returns a date formatted as a string
 
-* `date` A javascript `Date` object or a valid string to pass to the `Date` constructor
-* `tpl`  A string specifying what format to output the date in:
+  * `date`: A javascript `Date` object or a valid string to pass to the `Date` constructor
+  * `tpl`: A string specifying what format to output the date in:
+    - `'datetime'`: formats the date in the standard FT long format, including the time. E.g. `May 15, 2014 8:10 am`
+    - `'date'`: formats the date in the standard FT long format. E.g. `May 15, 2014`
+    - Any other string using [widespread conventions](http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) for time/date placeholders, which will be replaced with values extracted from the date provided. See `./main.js` for an up to date list of supported formats. To avoid e.g. the `mm` in `common` being replaced with the month prefix with a double backslash `co\\mmon` i.e. *In most cases custom date formats should not be used, in favour of the standard FT date and datetime formats*
 
-     - 'datetime': formats the date in the standard FT long format, including the time e.g. May 15, 2014 8:10 am
-     - 'date': formats the date in the standard FT long format e.g. May 15, 2014
-     - Any other string using [widespread conventions](http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) for time/date placeholders, which will be replaced with values extracted from the date provided. See './main.js' for an up to date list of supported formats.
-     To avoid e.g. the 'mm' in 'common' being replaced with the month prefix with a double backslash 'co\\mmon' i.e. *In most cases custom date formats should not be used, in favour of the standard FT date and datetime formats'*
+#### o-date#timeAgo(date)
 
-### o-date#timeAgo(date)
+Returns the relative time since the given date, formatted as a human readable string e.g. `13 minutes ago`.
 
-Returns the relative time since the given date, formatted as a human readable string e.g. '13 minutes ago'.
-
-### o-date#ftTime(date)
+#### o-date#ftTime(date)
 
 Returns relative time or timestamp for a given date, in accordance with FT date formatting conventions.
 
-* `date` A javascript `Date` object or a valid string to pass to the `Date` constructor
+  * `date`: A javascript `Date` object or a valid string to pass to the `Date` constructor
 
-### o-date#asTodayOrYesterdayOrNothing(date)
+#### o-date#asTodayOrYesterdayOrNothing(date)
 
-Returns ["yesterday"|"today"|""] for a given date. You can request this formatting for `o-date` components by adding `data-o-date-format="today-or-yesterday-or-nothing"`.
+Returns `'yesterday'`, `'today'` or `''` for a given date. You can request this formatting for `o-date` components by adding `data-o-date-format="today-or-yesterday-or-nothing"`.
 
-* `date` A javascript `Date` object or a valid string to pass to the `Date` constructor
+  * `date`: A javascript `Date` object or a valid string to pass to the `Date` constructor
 
-### o-date#init(el)
+#### o-date#init(el)
 
 Within a given container element, converts dates to ftTime (see above) and periodically updates their values. Within the container all `<time>` elements with `o-date` in `data-o-component` will be updated. If a given `<time>` element contains an element with the class `o-date__printer` the relative time will be output here, otherwise it will replace the contents of the entire `<time>` element. Once the `<time>` element has been formatted by o-date, the attribute `data-o-date-js` is added, enabling conditional styling and/or hiding the date until it is correctly formatted.
 
-* `el` A `HTMLElement` within which to scan for `o-date` elements. If the element itself is a `<time>` element with `o-date` in `data-o-component`, then o-date will run directly on this element rather than querying for suitable elements within it.
+  * `el`: An `HTMLElement` within which to scan for `o-date` elements. If the element itself is a `<time>` element with `o-date` in `data-o-component`, then o-date will run directly on this element rather than querying for suitable elements within it.
+
+---
+
+## Contact
+
+If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-date/issues), visit [#ft-origami](https://financialtimes.slack.com/messages/ft-origami/) or email [Origami Support](mailto:origami-support@ft.com).
+
+---
+
+## Licence
+
+This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,14 @@
 {
   "name": "o-date",
+  "description": "Utility for formatting and updating dates",
   "main": [
     "main.js"
   ],
   "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
     "test",
-    "package.json"
+    "tests"
   ]
 }

--- a/demos/src/declarative.js
+++ b/demos/src/declarative.js
@@ -4,7 +4,7 @@ const dates = document.querySelectorAll('time:not([datetime])');
 today.setHours(now.getHours() - 6);
 
 for (let i = 0; i < dates.length; i++) {
-  dates[i].setAttribute('datetime', today.toISOString());
+	dates[i].setAttribute('datetime', today.toISOString());
 }
 
 require('./demo');

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,8 +1,5 @@
 /*eslint-env node*/
 
-// Karma configuration
-// Generated on Mon Apr 14 2014 12:27:18 GMT+0100 (BST)
-
 const BowerPlugin = require('bower-webpack-plugin');
 const path = require('path');
 const cwd = process.cwd();
@@ -16,19 +13,20 @@ module.exports = function(config) {
 
 		// frameworks to use
 		// available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-		frameworks: ['jasmine'],
-
+		frameworks: ['mocha', 'sinon'],
 
 		plugins: [
-			'karma-jasmine',
-			'karma-phantomjs2-launcher',
-			'karma-webpack'
+			'karma-mocha',
+			'karma-phantomjs-launcher',
+			'karma-webpack',
+			'karma-sinon',
+			'karma-coverage'
 		],
 
 
 		// list of files / patterns to load in the browser
 		files: [
-			'http://polyfill.webservices.ft.com/v1/polyfill.js',
+			'http://cdn.polyfill.io/v2/polyfill.js?features=fetch&flags=gated',
 			'test/*.test.js'
 		],
 
@@ -41,15 +39,18 @@ module.exports = function(config) {
 		// preprocess matching files before serving them to the browser
 		// available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
 		preprocessors: {
-			'test/*.test.js': ['webpack']
+			'test/**/*.test.js': ['webpack']
 		},
 
 
 		// test results reporter to use
-		// possible values: 'dots', 'progress'
+		// possible values: 'dots', 'progress', 'coverage'
 		// available reporters: https://npmjs.org/browse/keyword/karma-reporter
-		reporters: ['progress'],
+		reporters: ['progress', 'coverage'],
 
+		coverageReporter: {
+			type : 'text-summary'
+		},
 
 		// web server port
 		port: 9876,
@@ -70,7 +71,7 @@ module.exports = function(config) {
 
 		// start these browsers
 		// available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-		browsers: ['PhantomJS2'],
+		browsers: ['PhantomJS'],
 
 
 		// Continuous Integration mode
@@ -88,7 +89,21 @@ module.exports = function(config) {
 							'babel?optional[]=runtime',
 							'imports?define=>false'
 						]
+					},
+					{
+						test: /\.json$/,
+						loader: 'json'
 					}
+				],
+				postLoaders: [
+					{ //delays coverage til after tests are run, fixing transpiled source coverage error
+						test: /\.js$/,
+						exclude: /(test|node_modules|bower_components)\//,
+						loader: 'istanbul-instrumenter'
+					}
+				],
+				noParse: [
+					/\/sinon\.js/,
 				]
 			},
 			resolve: {

--- a/origami.json
+++ b/origami.json
@@ -24,14 +24,13 @@
 			"name": "declarative",
 			"template": "demos/src/declarative.mustache",
 			"js": "demos/src/declarative.js",
-			"expanded": true,
 			"description": "Date will be set using the string in the datetime attribute and rendered as an absolute date as it was over a year ago."
 		},
 		{
 			"name": "imperative",
 			"template": "demos/src/imperative.mustache",
 			"js": "demos/src/imperative.js",
-			"expanded": false,
+			"hidden": true,
 			"description": "We're setting the datetime attribute on both date elements imperatively and these are then rendered as relative dates"
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -1,34 +1,37 @@
 {
   "name": "o-date",
   "version": "0.0.0",
-  "description": "FT branded dates",
+  "description": "Utility for formatting and updating dates",
   "main": "main.js",
+  "private": true,
   "scripts": {
-    "test": "./node_modules/karma/bin/karma start karma.conf.js"
+    "test": "karma start karma.conf.js"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/Financial-Times/o-date.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/Financial-Times/o-date/issues"
   },
   "homepage": "https://github.com/Financial-Times/o-date",
   "devDependencies": {
     "babel-loader": "^5.3.2",
-    "babel-runtime": "5.8.25",
-    "babelify": "^5.0.4",
+    "babel-runtime": "^5.6.15",
     "bower-webpack-plugin": "^0.1.8",
-    "debowerify": "^1.2.0",
-    "expect.js": "^0.3.1",
     "imports-loader": "^0.6.4",
-    "jasmine-core": "^2.5.2",
-    "karma": "^0.13.0",
-    "karma-jasmine": "^0.3.5",
-    "karma-phantomjs2-launcher": "^0.5.0",
+    "istanbul-instrumenter-loader": "^1.0.0",
+    "karma": "^0.13.22",
+    "karma-coverage": "^1.1.1",
+    "karma-mocha": "^0.2.2",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "karma-sinon": "^1.0.5",
     "karma-webpack": "^1.7.0",
-    "webpack": "^1.12.2"
+    "mocha": "^3.0.2",
+    "origami-build-tools": "^5.5.0",
+    "proclaim": "^3.4.1",
+    "sinon": "^1.17.5"
   }
 }

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -1,5 +1,7 @@
-/*global describe, it, expect, spyOn*/
-/*eslint-env jasmine */
+/* eslint-env mocha */
+import proclaim from 'proclaim';
+import sinon from 'sinon/pkg/sinon';
+
 const oDate = require('../main');
 
 describe('o-date', () => {
@@ -16,7 +18,7 @@ describe('o-date', () => {
 
 	describe('toDate', () => {
 		it('returns `undefined` if the passed in argument isnt a date', () => {
-			expect(oDate.toDate('hello')).toBe(undefined);
+			proclaim.isUndefined(oDate.toDate('hello'));
 		});
 
 		it('returns a date object if the date passed in is valid', () => {
@@ -30,8 +32,8 @@ describe('o-date', () => {
 				let testDate = oDate.toDate(date);
 				let testDateAsDate = new Date(testDate);
 
-				expect(testDate instanceof Date).toBe(true); // It should be a Date object
-				expect(testDateAsDate.getTime()).toBe(testDate.getTime()); // It should represent the date passed in
+				proclaim.isInstanceOf(testDate, Date); // It should be a Date object
+				proclaim.strictEqual(testDateAsDate.getTime(), testDate.getTime()); // It should represent the date passed in
 			}
 		});
 	});
@@ -49,22 +51,23 @@ describe('o-date', () => {
 		};
 
 		it('calls ODate.toDate() with the date argument passed in', () => {
-			spyOn(oDate, 'toDate');
+			sinon.spy(oDate, 'toDate');
 			oDate.format(someDate);
-			expect(oDate.toDate).toHaveBeenCalledWith(someDate);
+			proclaim.isTrue(oDate.toDate.withArgs(someDate).calledOnce);
+			oDate.toDate.restore();
 		});
 
 		it('returns a date if "date" is passed in as a second argument', () => {
-			expect(oDate.format(someDate, "date")).toBe('July 18, 2016');
+			proclaim.strictEqual(oDate.format(someDate, "date"), 'July 18, 2016');
 		});
 
 		it('returns a datetime if "datetime" is passed in as a second argument', () => {
-			expect(oDate.format(someDate, "datetime")).toBe('July 18, 2016 11:12 pm');
+			proclaim.strictEqual(oDate.format(someDate, "datetime"), 'July 18, 2016 11:12 pm');
 		});
 
 		it('doesnt zero pad single digit hours', () => {
 			const someDate = new Date("Mon Jul 18 2016 06:12:11");
-			expect(oDate.format(someDate, "datetime")).toBe('July 18, 2016 6:12 am');
+			proclaim.strictEqual(oDate.format(someDate, "datetime"), 'July 18, 2016 6:12 am');
 		});
 
 		// This is a bit of a cop-out really as what we're testing here is oDate's
@@ -72,99 +75,104 @@ describe('o-date', () => {
 		it('accepts date formatting functions', () => {
 			const date = new Date(2000, 1, 5, 6, 7, 22, 499);
 
-			expect(oDate.format(date, 'yyyy yy')).toBe('2000 00');
-			expect(oDate.format(date, 'MMMM MMM MM M')).toBe('February Feb 02 2');
-			expect(oDate.format(date, 'EEEE EEE')).toBe('Saturday Sat');
-			expect(oDate.format(date, 'd dd')).toBe('5 05');
-			expect(oDate.format(date, 'h hh')).toBe('6 06');
-			expect(oDate.format(date, 'm mm')).toBe('7 07');
-			expect(oDate.format(date, 'a')).toBe('am');
-			expect(oDate.format(date, 'This is \\a co\\mmon string mm')).toBe('This is a common string 07');
+			proclaim.strictEqual(oDate.format(date, 'yyyy yy'), '2000 00');
+			proclaim.strictEqual(oDate.format(date, 'MMMM MMM MM M'), 'February Feb 02 2');
+			proclaim.strictEqual(oDate.format(date, 'EEEE EEE'), 'Saturday Sat');
+			proclaim.strictEqual(oDate.format(date, 'd dd'), '5 05');
+			proclaim.strictEqual(oDate.format(date, 'h hh'), '6 06');
+			proclaim.strictEqual(oDate.format(date, 'm mm'), '7 07');
+			proclaim.strictEqual(oDate.format(date, 'a'), 'am');
+			proclaim.strictEqual(oDate.format(date, 'This is \\a co\\mmon string mm'), 'This is a common string 07');
 		});
 
 		it('returns an unpadded 12hour clock value for `h` format', () => {
-			expect(oDate.format(someTimes["midnight"], 'h')).toBe('12');
-			expect(oDate.format(someTimes["1am"], 'h')).toBe('1');
-			expect(oDate.format(someTimes["10am"], 'h')).toBe('10');
-			expect(oDate.format(someTimes["midday"], 'h')).toBe('12');
-			expect(oDate.format(someTimes["1pm"], 'h')).toBe('1');
-			expect(oDate.format(someTimes["11pm"], 'h')).toBe('11');
+			proclaim.strictEqual(oDate.format(someTimes["midnight"], 'h'), '12');
+			proclaim.strictEqual(oDate.format(someTimes["1am"], 'h'), '1');
+			proclaim.strictEqual(oDate.format(someTimes["10am"], 'h'), '10');
+			proclaim.strictEqual(oDate.format(someTimes["midday"], 'h'), '12');
+			proclaim.strictEqual(oDate.format(someTimes["1pm"], 'h'), '1');
+			proclaim.strictEqual(oDate.format(someTimes["11pm"], 'h'), '11');
 		});
 
 		it('returns a padded 12hour clock value for `hh` format', () => {
-			expect(oDate.format(someTimes["midnight"], 'hh')).toBe('12');
-			expect(oDate.format(someTimes["1am"], 'hh')).toBe('01');
-			expect(oDate.format(someTimes["10am"], 'hh')).toBe('10');
-			expect(oDate.format(someTimes["midday"], 'hh')).toBe('12');
-			expect(oDate.format(someTimes["1pm"], 'hh')).toBe('01');
-			expect(oDate.format(someTimes["11pm"], 'hh')).toBe('11');
+			proclaim.strictEqual(oDate.format(someTimes["midnight"], 'hh'), '12');
+			proclaim.strictEqual(oDate.format(someTimes["1am"], 'hh'), '01');
+			proclaim.strictEqual(oDate.format(someTimes["10am"], 'hh'), '10');
+			proclaim.strictEqual(oDate.format(someTimes["midday"], 'hh'), '12');
+			proclaim.strictEqual(oDate.format(someTimes["1pm"], 'hh'), '01');
+			proclaim.strictEqual(oDate.format(someTimes["11pm"], 'hh'), '11');
 		});
 
 		it('returns an unpadded 24hour clock value for `H` format', () => {
-			expect(oDate.format(someTimes["midnight"], 'H')).toBe('0');
-			expect(oDate.format(someTimes["1am"], 'H')).toBe('1');
-			expect(oDate.format(someTimes["10am"], 'H')).toBe('10');
-			expect(oDate.format(someTimes["midday"], 'H')).toBe('12');
-			expect(oDate.format(someTimes["1pm"], 'H')).toBe('13');
-			expect(oDate.format(someTimes["11pm"], 'H')).toBe('23');
+			proclaim.strictEqual(oDate.format(someTimes["midnight"], 'H'), '0');
+			proclaim.strictEqual(oDate.format(someTimes["1am"], 'H'), '1');
+			proclaim.strictEqual(oDate.format(someTimes["10am"], 'H'), '10');
+			proclaim.strictEqual(oDate.format(someTimes["midday"], 'H'), '12');
+			proclaim.strictEqual(oDate.format(someTimes["1pm"], 'H'), '13');
+			proclaim.strictEqual(oDate.format(someTimes["11pm"], 'H'), '23');
 		});
 
 		it('returns an padded 24hour clock value for `HH` format', () => {
-			expect(oDate.format(someTimes["midnight"], 'HH')).toBe('00');
-			expect(oDate.format(someTimes["1am"], 'HH')).toBe('01');
-			expect(oDate.format(someTimes["10am"], 'HH')).toBe('10');
-			expect(oDate.format(someTimes["midday"], 'HH')).toBe('12');
-			expect(oDate.format(someTimes["1pm"], 'HH')).toBe('13');
-			expect(oDate.format(someTimes["11pm"], 'HH')).toBe('23');
+			proclaim.strictEqual(oDate.format(someTimes["midnight"], 'HH'), '00');
+			proclaim.strictEqual(oDate.format(someTimes["1am"], 'HH'), '01');
+			proclaim.strictEqual(oDate.format(someTimes["10am"], 'HH'), '10');
+			proclaim.strictEqual(oDate.format(someTimes["midday"], 'HH'), '12');
+			proclaim.strictEqual(oDate.format(someTimes["1pm"], 'HH'), '13');
+			proclaim.strictEqual(oDate.format(someTimes["11pm"], 'HH'), '23');
 		});
 	});
 
 	describe('ODate.ftTime', () => {
 
 		const someDate = new Date("Jul 13 2016 00:02:00");
-		beforeEach(() => {
-			jasmine.clock().install();
-		});
-
-		afterEach(() => {
-			jasmine.clock().uninstall();
-		});
 
 		it('returns "just now" if ODate.isNearFuture returns true', () => {
-			spyOn(oDate, 'isNearFuture').and.returnValue(true);
-			expect(oDate.ftTime(someDate)).toEqual('just now');
+			sinon.stub(oDate, 'isNearFuture').returns(true);
+			proclaim.strictEqual(oDate.ftTime(someDate), 'just now');
+			oDate.isNearFuture.restore();
 		});
 
 		it('doesnt return just now if ODate.isNearFuture returns false', () => {
-			spyOn(oDate, 'isNearFuture').and.returnValue(false);
-			expect(oDate.ftTime(someDate)).not.toEqual('just now');
+			sinon.stub(oDate, 'isNearFuture').returns(false);
+			proclaim.notStrictEqual(oDate.ftTime(someDate), 'just now');
+			oDate.isNearFuture.restore();
 		});
 
 		it('returns a result from ODate.format if ODate.isFarFuture returns true', () => {
 			const oDateFormatReturn = "spy return value";
-			spyOn(oDate, 'isNearFuture').and.returnValue(false);
-			spyOn(oDate, 'isFarFuture').and.returnValue(true);
-			spyOn(oDate, 'format').and.returnValue(oDateFormatReturn);
+			sinon.stub(oDate, 'isNearFuture').returns(false);
+			sinon.stub(oDate, 'isFarFuture').returns(true);
+			sinon.stub(oDate, 'format').returns(oDateFormatReturn);
 
-			expect(oDate.ftTime(someDate)).toBe(oDateFormatReturn);
-			expect(oDate.format).toHaveBeenCalledWith(someDate, 'date');
+			proclaim.strictEqual(oDate.ftTime(someDate), oDateFormatReturn);
+			proclaim.isTrue(oDate.format.withArgs(someDate, 'date').calledOnce);
+
+			oDate.isNearFuture.restore();
+			oDate.isFarFuture.restore();
+			oDate.format.restore();
 		});
 
 		it('returns a result from ODate.timeAgo if ODate.isToday returns true', () => {
 			const oDateTimeAgoReturn = "mocked timeAgo date";
-			spyOn(oDate, 'isNearFuture').and.returnValue(false);
-			spyOn(oDate, 'isFarFuture').and.returnValue(false);
-			spyOn(oDate, 'isToday').and.returnValue(true);
+			sinon.stub(oDate, 'isNearFuture').returns(false);
+			sinon.stub(oDate, 'isFarFuture').returns(false);
+			sinon.stub(oDate, 'isToday').returns(true);
+			sinon.stub(oDate, 'timeAgo').returns(oDateTimeAgoReturn);
 
-			spyOn(oDate, 'timeAgo').and.returnValue(oDateTimeAgoReturn);
+			proclaim.strictEqual(oDate.ftTime(someDate), oDateTimeAgoReturn);
+			const call = oDate.timeAgo.firstCall;
+			proclaim.strictEqual(call.args[0], someDate);
+			proclaim.isNumber(call.args[1]);
 
-			expect(oDate.ftTime(someDate)).toBe(oDateTimeAgoReturn);
-			expect(oDate.timeAgo).toHaveBeenCalledWith(someDate, jasmine.any(Number));
+			oDate.isNearFuture.restore();
+			oDate.isFarFuture.restore();
+			oDate.isToday.restore();
+			oDate.timeAgo.restore();
 		});
 
 		it('returns a result from timeAgo if the publish date is less than 4 hours ago even if that date is also yesterday', ()=>{
 			const oDateTimeAgoReturn = "mocked timeAgo date";
-			spyOn(oDate, 'timeAgo').and.returnValue(oDateTimeAgoReturn);
+			sinon.stub(oDate, 'timeAgo').returns(oDateTimeAgoReturn);
 
 			const publishDatesInTheLast4Hours = [
 				new Date("Jul 13 2016 23:02:49"),
@@ -174,20 +182,23 @@ describe('o-date', () => {
 			];
 
 			const fakeNow = new Date("Jul 14 2016 00:02:49");
-			jasmine.clock().mockDate(fakeNow);
+			sinon.stub(window, 'Date').returns(fakeNow);
+
 			for (let date of publishDatesInTheLast4Hours) {
-				expect(oDate.ftTime(date)).toBe(oDateTimeAgoReturn);
-				expect(oDate.timeAgo).toHaveBeenCalledWith(date, jasmine.any(Number));
+				proclaim.strictEqual(oDate.ftTime(date), oDateTimeAgoReturn);
+				proclaim.isTrue(oDate.timeAgo.withArgs(date).called);
 			}
+
+			oDate.timeAgo.restore();
+			window.Date.restore();
 		});
 
 		it('doesnt return a result from timeAgo if the publish date is more than 4 hours ago and isToday is false', ()=>{
 			const oDateTimeAgoReturn = "mocked timeAgo date";
-			spyOn(oDate, 'timeAgo').and.returnValue(oDateTimeAgoReturn);
-
-			spyOn(oDate, 'isNearFuture').and.returnValue(false);
-			spyOn(oDate, 'isFarFuture').and.returnValue(false);
-			spyOn(oDate, 'isToday').and.returnValue(false);
+			sinon.stub(oDate, 'timeAgo').returns(oDateTimeAgoReturn);
+			sinon.stub(oDate, 'isNearFuture').returns(false);
+			sinon.stub(oDate, 'isFarFuture').returns(false);
+			sinon.stub(oDate, 'isToday').returns(false);
 
 			const publishDatesInTheLast4Hours = [
 				new Date("Jul 13 2016 19:02:49"),
@@ -197,69 +208,86 @@ describe('o-date', () => {
 			];
 
 			const fakeNow = new Date("Jul 14 2016 00:02:49");
-			jasmine.clock().mockDate(fakeNow);
+			sinon.stub(window, 'Date').returns(fakeNow);
+
 			for (let date of publishDatesInTheLast4Hours) {
-				expect(oDate.ftTime(date)).not.toBe(oDateTimeAgoReturn);
-				expect(oDate.timeAgo).not.toHaveBeenCalledWith(date, jasmine.any(Number));
+				proclaim.notStrictEqual(oDate.ftTime(date), oDateTimeAgoReturn);
+				proclaim.isTrue(oDate.timeAgo.neverCalledWith(date));
 			}
+
+			oDate.timeAgo.restore();
+			oDate.isNearFuture.restore();
+			oDate.isFarFuture.restore();
+			oDate.isToday.restore();
+			window.Date.restore();
 		});
 
 		it('returns a result from "yesterday" if ODate.isYesterday returns true', () => {
-			spyOn(oDate, 'isNearFuture').and.returnValue(false);
-			spyOn(oDate, 'isFarFuture').and.returnValue(false);
-			spyOn(oDate, 'isToday').and.returnValue(false);
-			spyOn(oDate, 'isYesterday').and.returnValue(true);
+			sinon.stub(oDate, 'isNearFuture').returns(false);
+			sinon.stub(oDate, 'isFarFuture').returns(false);
+			sinon.stub(oDate, 'isToday').returns(false);
+			sinon.stub(oDate, 'isYesterday').returns(true);
 
-			expect(oDate.ftTime(someDate)).toBe('yesterday');
+			proclaim.strictEqual(oDate.ftTime(someDate), 'yesterday');
+
+			oDate.isNearFuture.restore();
+			oDate.isFarFuture.restore();
+			oDate.isToday.restore();
+			oDate.isYesterday.restore();
 		});
 
 		it('returns the result of ODate.format if none of the date matchers return true', () => {
-			spyOn(oDate, 'isNearFuture').and.returnValue(false);
-			spyOn(oDate, 'isFarFuture').and.returnValue(false);
-			spyOn(oDate, 'isToday').and.returnValue(false);
-			spyOn(oDate, 'isYesterday').and.returnValue(false);
-			spyOn(oDate, 'format').and.returnValue('a pretend date string');
+			sinon.stub(oDate, 'isNearFuture').returns(false);
+			sinon.stub(oDate, 'isFarFuture').returns(false);
+			sinon.stub(oDate, 'isToday').returns(false);
+			sinon.stub(oDate, 'isYesterday').returns(false);
+			sinon.stub(oDate, 'format').returns('a pretend date string');
 
-			expect(oDate.ftTime(someDate)).toBe('a pretend date string');
+			proclaim.strictEqual(oDate.ftTime(someDate), 'a pretend date string');
+
+			oDate.isNearFuture.restore();
+			oDate.isFarFuture.restore();
+			oDate.isToday.restore();
+			oDate.isYesterday.restore();
+			oDate.format.restore();
 		});
 	});
 
 	describe('isNearFuture', () => {
 		it('returns true if the interval is less than 5 mins in the future', () => {
-			expect(oDate.isNearFuture(- inSeconds.minute)).toEqual(true);
-			expect(oDate.isNearFuture(- inSeconds.second)).toEqual(true);
+			proclaim.isTrue(oDate.isNearFuture(- inSeconds.minute));
+			proclaim.isTrue(oDate.isNearFuture(- inSeconds.second));
 		});
 		it('returns false if the interval is more than 5 mins in the future', () => {
-			expect(oDate.isNearFuture(- 100 * inSeconds.hour)).toEqual(false);
-			expect(oDate.isNearFuture(- inSeconds.hour)).toEqual(false);
-			expect(oDate.isNearFuture(- 10 * inSeconds.minute)).toEqual(false);
-
+			proclaim.isFalse(oDate.isNearFuture(- 100 * inSeconds.hour));
+			proclaim.isFalse(oDate.isNearFuture(- inSeconds.hour));
+			proclaim.isFalse(oDate.isNearFuture(- 10 * inSeconds.minute));
 		});
 		it('returns false if the interval in the past', () => {
-			expect(oDate.isNearFuture(inSeconds.hour)).toEqual(false);
-			expect(oDate.isNearFuture(10 * inSeconds.minute)).toEqual(false);
-			expect(oDate.isNearFuture(5 * inSeconds.minute)).toEqual(false);
-			expect(oDate.isNearFuture(inSeconds.second)).toEqual(false);
+			proclaim.isFalse(oDate.isNearFuture(inSeconds.hour));
+			proclaim.isFalse(oDate.isNearFuture(10 * inSeconds.minute));
+			proclaim.isFalse(oDate.isNearFuture(5 * inSeconds.minute));
+			proclaim.isFalse(oDate.isNearFuture(inSeconds.second));
 		});
 	});
 
 	describe('isFarFuture', () => {
 		it('returns true if the interval ismore than 5 mins in the future', () => {
-			expect(oDate.isFarFuture(- 100 * inSeconds.hour)).toEqual(true);
-			expect(oDate.isFarFuture(- inSeconds.hour)).toEqual(true);
-			expect(oDate.isFarFuture(- 10 * inSeconds.minute)).toEqual(true);
+			proclaim.isTrue(oDate.isFarFuture(- 100 * inSeconds.hour));
+			proclaim.isTrue(oDate.isFarFuture(- inSeconds.hour));
+			proclaim.isTrue(oDate.isFarFuture(- 10 * inSeconds.minute));
 		});
 		it('returns false if the interval is less than 5 mins in the future', () => {
-			expect(oDate.isFarFuture(- 5 * inSeconds.minute)).toEqual(false);
-			expect(oDate.isFarFuture(- inSeconds.minute)).toEqual(false);
-			expect(oDate.isFarFuture(- inSeconds.second)).toEqual(false);
+			proclaim.isFalse(oDate.isFarFuture(- 5 * inSeconds.minute));
+			proclaim.isFalse(oDate.isFarFuture(- inSeconds.minute));
+			proclaim.isFalse(oDate.isFarFuture(- inSeconds.second));
 
 		});
 		it('returns false if the interval in the past', () => {
-			expect(oDate.isFarFuture(inSeconds.hour)).toEqual(false);
-			expect(oDate.isFarFuture(10 * inSeconds.minute)).toEqual(false);
-			expect(oDate.isFarFuture(5 * inSeconds.minute)).toEqual(false);
-			expect(oDate.isFarFuture(inSeconds.second)).toEqual(false);
+			proclaim.isFalse(oDate.isFarFuture(inSeconds.hour));
+			proclaim.isFalse(oDate.isFarFuture(10 * inSeconds.minute));
+			proclaim.isFalse(oDate.isFarFuture(5 * inSeconds.minute));
+			proclaim.isFalse(oDate.isFarFuture(inSeconds.second));
 		});
 	});
 
@@ -267,23 +295,23 @@ describe('o-date', () => {
 		it('returns true if the dates passed in are the same day', () => {
 			const publishDate = new Date("Jul 13 2016 10:02:00");
 			const interval = inSeconds.hour;
-			const now = new Date(publishDate.getTime() + (interval*1000));
-			expect(oDate.isToday(publishDate, now, interval)).toEqual(true);
+			const now = new Date(publishDate.getTime() + (interval * 1000));
+			proclaim.isTrue(oDate.isToday(publishDate, now, interval));
 		});
 		it('returns false if the dates passed in are not same day', () => {
 			const publishDate = new Date("Jul 13 2016 10:02:00");
 			const interval = inSeconds.day;
-			const now = new Date(publishDate.getTime() + (interval*1000));
-			expect(oDate.isToday(publishDate, now, interval)).toEqual(false);
+			const now = new Date(publishDate.getTime() + (interval * 1000));
+			proclaim.isFalse(oDate.isToday(publishDate, now, interval));
 		});
 		it('returns false if the dates are both tuesday but more than 24h apart', () => {
 			const publishDate = new Date("Jul 13 2016 10:02:00");
 			const interval = inSeconds.week;
-			const now = new Date(publishDate.getTime() + (interval*1000));
+			const now = new Date(publishDate.getTime() + (interval * 1000));
 
 			// These two dates are the "same day" but a week apart.
-			expect(publishDate.getDay()).toEqual(now.getDay());
-			expect(oDate.isToday(publishDate, now, interval)).toEqual(false);
+			proclaim.strictEqual(publishDate.getDay(), now.getDay());
+			proclaim.isFalse(oDate.isToday(publishDate, now, interval));
 		});
 	});
 
@@ -291,138 +319,146 @@ describe('o-date', () => {
 		it('returns true if the date passed in is yesterday', () => {
 			const publishDate = new Date("Jul 13 2016 10:02:00");
 			const interval = inSeconds.day;
-			const now = new Date(publishDate.getTime() + (interval*1000));
-			expect(oDate.isYesterday(publishDate, now, interval)).toEqual(true);
+			const now = new Date(publishDate.getTime() + (interval * 1000));
+			proclaim.isTrue(oDate.isYesterday(publishDate, now, interval));
 		});
 
 		it('returns false if the dates passed are the same day', () => {
 			const publishDate = new Date("Jul 13 2016 10:02:00");
 			const interval = inSeconds.hour;
-			const now = new Date(publishDate.getTime() + (interval*1000));
-			expect(oDate.isYesterday(publishDate, now, interval)).toEqual(false);
+			const now = new Date(publishDate.getTime() + (interval * 1000));
+			proclaim.isFalse(oDate.isYesterday(publishDate, now, interval));
 		});
 
 		it('returns false if the weekdays are 1 apart but more than 24h apart', () => {
 			const publishDate = new Date("Jul 13 2016 10:02:00");
 			const interval = inSeconds.week + inSeconds.day;
-			const now = new Date(publishDate.getTime() + (interval*1000));
+			const now = new Date(publishDate.getTime() + (interval * 1000));
 
 			// These two dates are the "day after eachother (wednesday and thursday)"
 			// but a week apart.
-			expect(publishDate.getDay()).toEqual(now.getDay()-1);
-			expect(oDate.isYesterday(publishDate, now, interval)).toEqual(false);
+			proclaim.strictEqual(publishDate.getDay(), now.getDay() - 1);
+			proclaim.isFalse(oDate.isYesterday(publishDate, now, interval));
 		});
 	});
 
 	describe('ODate.timeAgo', () => {
+		let OriginalDate;
+		let mockDate;
+
 		beforeEach(() => {
-			// Since these tests use now(), stub the time so that it's not possible
-			// for these tests to pass at some times of day but fail at others.
-			const fakeNow = new Date("Jul 13 2016 10:02:49");
-			jasmine.clock().install();
-			jasmine.clock().mockDate(fakeNow);
+			// This is a convoluted way of ensuring that we always get
+			// the same date when `Date` is called. We default the input
+			// to a fixed point in time, but allow it to be specified –
+			// this ensures that `oDate.toDate` still works.
+			OriginalDate = Date;
+			mockDate = 'Jul 13 2016 10:02:49';
+			Date = sinon.spy(input => {
+				input = input || mockDate;
+				return new OriginalDate(input);
+			});
 		});
 
 		afterEach(() => {
-			jasmine.clock().uninstall();
+			Date = OriginalDate;
 		});
 
 		it('accepts a value in seconds and returns a corresponding string', () => {
 			const formatsLow = {
 				'2 seconds ago': 2 * inSeconds.second,
-				'a minute ago':	inSeconds.minute,
+				'a minute ago': inSeconds.minute,
 				'2 minutes ago': 90 * inSeconds.second,
-				'an hour ago':	 inSeconds.hour,
-				'2 hours ago':	 90 * inSeconds.minute,
-				'a day ago':		 22 * inSeconds.hour,
-				'2 days ago':		36 * inSeconds.hour,
-				'a month ago':	 25 * inSeconds.day,
-				'2 months ago':	45 * inSeconds.day,
-				'a year ago':	 345 * inSeconds.day,
-				'2 years ago':	547 * inSeconds.day,
+				'an hour ago': inSeconds.hour,
+				'2 hours ago': 90 * inSeconds.minute,
+				'a day ago': 22 * inSeconds.hour,
+				'2 days ago': 36 * inSeconds.hour,
+				'a month ago': 25 * inSeconds.day,
+				'2 months ago': 45 * inSeconds.day,
+				'a year ago': 345 * inSeconds.day,
+				'2 years ago': 547 * inSeconds.day
 			};
 			const formatsHigh = {
 				'59 seconds ago': 59 * inSeconds.second,
-				'a minute ago':	 89 * inSeconds.second,
+				'a minute ago': 89 * inSeconds.second,
 				'59 minutes ago': 59 * inSeconds.minute - inSeconds.second,
-				'an hour ago':		90 * inSeconds.minute - inSeconds.second,
-				'22 hours ago':	 22 * inSeconds.hour - inSeconds.second,
-				'a day ago':			36 * inSeconds.hour - inSeconds.second,
-				'25 days ago':		25 * inSeconds.day - inSeconds.second,
-				'a month ago':		45 * inSeconds.day - inSeconds.second,
-				'11 months ago':	345 * inSeconds.day - inSeconds.second,
-				'a year ago':		 547 * inSeconds.day - inSeconds.second,
+				'an hour ago': 90 * inSeconds.minute - inSeconds.second,
+				'22 hours ago': 22 * inSeconds.hour - inSeconds.second,
+				'a day ago': 36 * inSeconds.hour - inSeconds.second,
+				'25 days ago': 25 * inSeconds.day - inSeconds.second,
+				'a month ago': 45 * inSeconds.day - inSeconds.second,
+				'11 months ago': 345 * inSeconds.day - inSeconds.second,
+				'a year ago': 547 * inSeconds.day - inSeconds.second
 			};
 
 			Object.keys(formatsLow).forEach(function (format) {
 				let date = new Date();
 				date = date - (formatsLow[format] * 1000);
-				expect(oDate.timeAgo(date)).toBe(format);
+				proclaim.strictEqual(oDate.timeAgo(date), format);
 			});
 
 			Object.keys(formatsHigh).forEach(function (format) {
 				let date = new Date();
 				date = date - (formatsHigh[format] * 1000);
-				expect(oDate.timeAgo(date)).toBe(format);
+				proclaim.strictEqual(oDate.timeAgo(date), format, `HIGH: ${format}`);
 			});
 		});
 
 		it('returns `undefined` if the param passed in is not a date', () => {
-			expect(oDate.timeAgo('not a date')).toBe(undefined);
+			proclaim.strictEqual(oDate.timeAgo('not a date'), undefined);
 		});
 
 		it('returns the timeAgo up to a limit if a limit value is provided', () => {
 			const publishDate = new Date('Jul 13 2016 10:02:49');
 			const datesWithinLimit = [
-				new Date('Jul 13 2016 11:02:48'), // 59 minutes and 59 seconds later
-				new Date('Jul 13 2016 10:02:50')  // 1 second later
+				'Jul 13 2016 11:02:48', // 59 minutes and 59 seconds later
+				'Jul 13 2016 10:02:50'  // 1 second later
 			];
 
 			for (let date of datesWithinLimit) {
-				jasmine.clock().mockDate(date);
-				expect(oDate.timeAgo(publishDate, {limit: inSeconds.hour})).not.toBe('');
+				mockDate = date;
+				proclaim.notStrictEqual(oDate.timeAgo(publishDate, {limit: inSeconds.hour}), '');
 			}
 		});
 
 		it('returns nothing if a limit is provided and the timeAgo is longer than that limit', () => {
 			const publishDate = new Date('Jul 13 2016 10:02:49');
 			const datesWithinLimit = [
-				new Date('Jul 13 2016 11:02:51'), // 60 minutes, 2 seconds later
-				new Date('Jul 13 2016 23:02:52'), // 12 hours, 3 seconds later
-				new Date('Jul 14 2016 10:02:49')  // the next day
+				'Jul 13 2016 11:02:51', // 60 minutes, 2 seconds later
+				'Jul 13 2016 23:02:52', // 12 hours, 3 seconds later
+				'Jul 14 2016 10:02:49'  // the next day
 			];
 
 			for (let date of datesWithinLimit) {
-				jasmine.clock().mockDate(date);
-				expect(oDate.timeAgo(publishDate, {limit: inSeconds.hour})).toBe('');
+				mockDate = date;
+				proclaim.strictEqual(oDate.timeAgo(publishDate, {limit: inSeconds.hour}), '');
 			}
 		});
 
 		it('accepts an interval option', () => {
 			const publishDate = new Date('Jul 13 2016 10:02:49');
 			const dates = [
-				new Date('Jul 13 2016 11:02:51'),
-				new Date('Jul 13 2016 23:02:52'),
-				new Date('Jul 14 2016 10:02:49')
+				'Jul 13 2016 11:02:51',
+				'Jul 13 2016 23:02:52',
+				'Jul 14 2016 10:02:49'
 			];
 
 			for (let date of dates) {
-				jasmine.clock().mockDate(date);
-				expect(oDate.timeAgo(publishDate, {interval: 5})).toBe('5 seconds ago');
+				mockDate = date;
+				proclaim.strictEqual(oDate.timeAgo(publishDate, {interval: 5}), '5 seconds ago');
 			}
 		});
 
 		it('accepts the interval option as a second argument for backwards compatibility', () => {
 			const publishDate = new Date('Jul 13 2016 10:02:49');
 			const dates = [
-				new Date('Jul 13 2016 11:02:51'),
-				new Date('Jul 13 2016 23:02:52'),
-				new Date('Jul 14 2016 10:02:49')
+				'Jul 13 2016 11:02:51',
+				'Jul 13 2016 23:02:52',
+				'Jul 14 2016 10:02:49'
 			];
 
 			for (let date of dates) {
-				jasmine.clock().mockDate(date);
-				expect(oDate.timeAgo(publishDate, 5)).toBe('5 seconds ago');
+				mockDate = date;
+				proclaim.strictEqual(oDate.timeAgo(publishDate, 5), '5 seconds ago');
 			}
 		});
 
@@ -444,56 +480,90 @@ describe('o-date', () => {
 			Object.keys(abbreviations).forEach(function (abbreviation) {
 				let date = new Date();
 				date = date - (abbreviations[abbreviation] * 1000);
-				expect(oDate.timeAgo(date, { abbreviated: true })).toBe(abbreviation);
+				proclaim.strictEqual(oDate.timeAgo(date, { abbreviated: true }), abbreviation);
 			});
 		});
 	});
 
+	// THIS ONE
 	describe('ODate.asTodayOrYesterdayOrNothing', () => {
+		let OriginalDate;
+		let mockDate;
+
 		beforeEach(() => {
-			// Since these tests use now(), stub the time so that it's not possible
-			// for these tests to pass at some times of day but fail at others.
-			const fakeNow = new Date("Jul 13 2016 10:02:49");
-			jasmine.clock().install();
-			jasmine.clock().mockDate(fakeNow);
+			// This is a convoluted way of ensuring that we always get
+			// the same date when `Date` is called. We default the input
+			// to a fixed point in time, but allow it to be specified –
+			// this ensures that `oDate.toDate` still works.
+			OriginalDate = Date;
+			mockDate = 'Jul 13 2016 10:02:49';
+			Date = sinon.spy(input => {
+				input = input || mockDate;
+				return new OriginalDate(input);
+			});
 		});
 
 		afterEach(() => {
-			jasmine.clock().uninstall();
+			Date = OriginalDate;
 		});
 
 		it('returns "today" if isToday returns true', () => {
-			spyOn(oDate, 'isToday').and.returnValue(true);
-			spyOn(oDate, 'isYesterday');
+			sinon.stub(oDate, 'isToday').returns(true);
+			sinon.spy(oDate, 'isYesterday');
 
 			const mockDate = "some date";
-			expect(oDate.asTodayOrYesterdayOrNothing(mockDate)).toBe('today');
+			proclaim.strictEqual(oDate.asTodayOrYesterdayOrNothing(mockDate), 'today');
 
-			expect(oDate.isToday).toHaveBeenCalledWith(mockDate, jasmine.any(Date), jasmine.any(Number));
-			expect(oDate.isYesterday).not.toHaveBeenCalled();
+			const call = oDate.isToday.firstCall;
+			proclaim.strictEqual(call.args[0], mockDate);
+			proclaim.isInstanceOf(call.args[1], OriginalDate);
+			proclaim.isNumber(call.args[2]);
+			proclaim.isFalse(oDate.isYesterday.called);
 
+			oDate.isToday.restore();
+			oDate.isYesterday.restore();
 		});
 
 		it('returns "yesterday" if isYesterday returns true AND isToday is false', () => {
-			 spyOn(oDate, 'isToday').and.returnValue(false);
-			 spyOn(oDate, 'isYesterday').and.returnValue(true);
+			sinon.stub(oDate, 'isToday').returns(false);
+			sinon.stub(oDate, 'isYesterday').returns(true);
 
-			 const mockDate = "some date";
-			 expect(oDate.asTodayOrYesterdayOrNothing(mockDate)).toBe('yesterday');
+			const mockDate = "some date";
+			proclaim.strictEqual(oDate.asTodayOrYesterdayOrNothing(mockDate), 'yesterday');
 
-			 expect(oDate.isToday).toHaveBeenCalledWith(mockDate, jasmine.any(Date), jasmine.any(Number));
-			 expect(oDate.isYesterday).toHaveBeenCalledWith(mockDate, jasmine.any(Date), jasmine.any(Number));
+			const todayCall = oDate.isToday.firstCall;
+			proclaim.strictEqual(todayCall.args[0], mockDate);
+			proclaim.isInstanceOf(todayCall.args[1], OriginalDate);
+			proclaim.isNumber(todayCall.args[2]);
+
+			const yesterdayCall = oDate.isToday.firstCall;
+			proclaim.strictEqual(yesterdayCall.args[0], mockDate);
+			proclaim.isInstanceOf(yesterdayCall.args[1], OriginalDate);
+			proclaim.isNumber(yesterdayCall.args[2]);
+
+			oDate.isToday.restore();
+			oDate.isYesterday.restore();
 		});
 
 		it("returns '' if isToday and isYesterday are both false", () => {
-			spyOn(oDate, 'isToday').and.returnValue(false);
-			spyOn(oDate, 'isYesterday').and.returnValue(false);
+			sinon.stub(oDate, 'isToday').returns(false);
+			sinon.stub(oDate, 'isYesterday').returns(false);
 
 			const mockDate = "some date";
-			expect(oDate.asTodayOrYesterdayOrNothing(mockDate)).toBe('');
+			proclaim.strictEqual(oDate.asTodayOrYesterdayOrNothing(mockDate), '');
 
-			expect(oDate.isToday).toHaveBeenCalledWith(mockDate, jasmine.any(Date), jasmine.any(Number));
-			expect(oDate.isYesterday).toHaveBeenCalledWith(mockDate, jasmine.any(Date), jasmine.any(Number));
+			const todayCall = oDate.isToday.firstCall;
+			proclaim.strictEqual(todayCall.args[0], mockDate);
+			proclaim.isInstanceOf(todayCall.args[1], OriginalDate);
+			proclaim.isNumber(todayCall.args[2]);
+
+			const yesterdayCall = oDate.isToday.firstCall;
+			proclaim.strictEqual(yesterdayCall.args[0], mockDate);
+			proclaim.isInstanceOf(yesterdayCall.args[1], OriginalDate);
+			proclaim.isNumber(yesterdayCall.args[2]);
+
+			oDate.isToday.restore();
+			oDate.isYesterday.restore();
 		});
 	});
 
@@ -501,15 +571,16 @@ describe('o-date', () => {
 		it('returns \'Less than a minute ago\' if time was less than a minute ago', () => {
 			let date;
 			date = new Date() - (2 * inSeconds.second * 1000); // 1 second ago
-			expect(oDate.timeAgoNoSeconds(date)).toBe('Less than a minute ago');
+			proclaim.strictEqual(oDate.timeAgoNoSeconds(date), 'Less than a minute ago');
 
 			date = new Date() - (59 * inSeconds.second * 1000); // 59 seconds ago
-			expect(oDate.timeAgoNoSeconds(date)).toBe('Less than a minute ago');
+			proclaim.strictEqual(oDate.timeAgoNoSeconds(date), 'Less than a minute ago');
 
 			date = new Date() - (60 * inSeconds.second * 1000); // 1 minute ago
-			spyOn(oDate, 'timeAgo');
+			sinon.spy(oDate, 'timeAgo');
 			oDate.timeAgoNoSeconds(date);
-			expect(expect(oDate.timeAgo).toHaveBeenCalledWith(date));
+			proclaim.isTrue(oDate.timeAgo.withArgs(date).calledOnce);
+			oDate.timeAgo.restore();
 		});
 	});
 });


### PR DESCRIPTION
Some of the tests in here are a little convoluted, because we have to
mock the global `Date` function. Sinon doesn't provide mocking of dates
in the same way as Jasmine so I've had to work around that.

I'm going to rewrite and simplify a lot of these in a later PR.