### PR TITLE
Add an option for a limitless abbreviated dateString

### DIFF
--- a/main.js
+++ b/main.js
@@ -108,6 +108,8 @@ ODate.prototype.update = function() {
 		dateString = ODate.format(date, 'date');
 	} else if (format === 'time-ago-limit-4-hours') {
 		dateString = ODate.timeAgo(date, { limit: 4*inSeconds.hour });
+	} else if (format === 'time-ago-abbreviated') {
+		dateString = ODate.timeAgo(date, { abbreviated: true });
 	} else if (format === 'time-ago-abbreviated-limit-4-hours') {
 		dateString = ODate.timeAgo(date, { abbreviated: true, limit: 4*inSeconds.hour });
 	} else if (format === 'time-ago-no-seconds') {

--- a/origami.json
+++ b/origami.json
@@ -28,6 +28,7 @@
 			"name": "declarative",
 			"template": "demos/src/declarative.mustache",
 			"js": "demos/src/declarative.js",
+			"title": "Declarative",
 			"description": "Date will be set using the string in the datetime attribute and rendered as an absolute date as it was over a year ago."
 		},
 		{
@@ -35,6 +36,7 @@
 			"template": "demos/src/imperative.mustache",
 			"js": "demos/src/imperative.js",
 			"hidden": true,
+			"title": "Imperative",
 			"description": "We're setting the datetime attribute on both date elements imperatively and these are then rendered as relative dates"
 		}
 	]


### PR DESCRIPTION
The use of `o-date` in n-topic-card [was using](https://github.com/Financial-Times/n-topic-card/pull/19/files#diff-9f6932470c59bfd7acbe14a80f6be4b3L38) the default format, but an [update to the design](https://trello-attachments.s3.amazonaws.com/5a4f85a8328c42dd87d468b0/5a8c382bee0d1dd4cbbee37f/14fda398b909f3ac40d27a5f11fb3233/Ad3_Copy_3%402x.png) asked for the [abbreviated style](https://github.com/Financial-Times/n-topic-card/pull/19/files#diff-9f6932470c59bfd7acbe14a80f6be4b3R37).

The only current option for abbreviated is with a limit of four hours, but the topic card is meant to display the time ago **_always._**

Please accept my humble [pull request](https://github.com/Financial-Times/o-date/pull/86) to add a limitless abbreviated `dateString` format.