### PR TITLE
Prevent empty dates being read by assistive tech

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,13 +87,16 @@ ODate.prototype.update = function() {
 		printer.innerHTML = dateString;
 	}
 
-	el.title = ftDateFormat.format(date, 'datetime');
 	el.setAttribute('data-o-date-js', '');
 
-	if (labelString) {
-		el.setAttribute('aria-label', labelString);
+	if (dateString) {
+		el.setAttribute('title', ftDateFormat.format(date, 'datetime'));
+		el.setAttribute('aria-label', labelString || dateString);
+		el.removeAttribute('aria-hidden');
 	} else {
-		el.setAttribute('aria-label', dateString);
+		el.removeAttribute('title');
+		el.removeAttribute('aria-label');
+		el.setAttribute('aria-hidden', '');
 	}
 };
 

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -3,103 +3,275 @@ import proclaim from 'proclaim';
 import sinon from 'sinon/pkg/sinon';
 
 const ODate = require('../main');
+const ftDateFormat = require('ft-date-format');
 
 describe('o-date DOM', () => {
 	let clock;
 	let sandbox;
 	let mockDateElement;
 
-	beforeEach(() => {
-		const fakeNow = new Date();
-		const elevenMinutesAgo = new Date(fakeNow);
-
-		elevenMinutesAgo.setMinutes(fakeNow.getMinutes() - 11);
-		clock = sinon.useFakeTimers(fakeNow);
-
-		sandbox = document.createElement('div');
-		sandbox.innerHTML = `<time data-o-component="o-date" datetime="${elevenMinutesAgo.toISOString()}" class="o-date"></time>`;
-		mockDateElement = sandbox.querySelector('[data-o-component="o-date"]');
-	});
-
-	afterEach(() => {
-		clock.restore();
-		sandbox = null;
-		mockDateElement = null;
-	});
-
-
-	describe('time-ago-limit-4-hours', () => {
-		beforeEach(() => {
-			mockDateElement.dataset.odateformat = 'time-ago-limit-4-hours';
-			new ODate(mockDateElement);
-		});
-
-		it('renders the date in the element', () => {
-			proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
-		});
-	});
-
-	describe('time-ago-abbreviated', () => {
+	describe('11 minutes ago', () => {
+		let elevenMinutesAgoDateTime;
 
 		beforeEach(() => {
-			mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated';
-			new ODate(mockDateElement);
+			const fakeNow = new Date();
+			const elevenMinutesAgo = new Date(fakeNow);
+
+			elevenMinutesAgo.setMinutes(fakeNow.getMinutes() - 11);
+			clock = sinon.useFakeTimers(fakeNow);
+
+			elevenMinutesAgoDateTime = ftDateFormat.format(elevenMinutesAgo, 'datetime');
+
+			sandbox = document.createElement('div');
+			sandbox.innerHTML = `<time data-o-component="o-date" datetime="${elevenMinutesAgo.toISOString()}" class="o-date"></time>`;
+			mockDateElement = sandbox.querySelector('[data-o-component="o-date"]');
 		});
 
-		it('renders the date in the element', () => {
-			proclaim.equal(mockDateElement.innerHTML, '11m ago');
+		afterEach(() => {
+			clock.restore();
+			sandbox = null;
+			mockDateElement = null;
 		});
 
-		it('adds a aria label with a non-abbreviated unit', () => {
-			proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+		describe('time-ago-limit-4-hours', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.odateformat = 'time-ago-limit-4-hours';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
+			});
+
+			it('adds an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
+		});
+
+		describe('time-ago-abbreviated', () => {
+
+			beforeEach(() => {
+				mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '11m ago');
+			});
+
+			it('adds an aria-label attribute with a non-abbreviated unit', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
+		});
+
+		describe('time-ago-abbreviated-limit-4-hours', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated-limit-4-hours';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '11m ago');
+			});
+
+			it('adds an aria-label attribute with a non-abbreviated unit', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
+		});
+
+		describe('today-or-yesterday-or-nothing', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.oDateFormat = 'today-or-yesterday-or-nothing';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, 'today');
+			});
+
+			it('adds an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), 'today');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
+		});
+
+		describe('date-only', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.odateformat = 'date-only';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
+			});
+
+			it('adds an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
+		});
+
+		describe('time-ago-no-seconds', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.odateformat = 'time-ago-no-seconds';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
+			});
+
+			it('adds an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
 		});
 	});
 
-	describe('time-ago-abbreviated-limit-4-hours', () => {
+	describe('5 hours ago', () => {
+		let fiveHoursAgoDateTime;
+
 		beforeEach(() => {
-			mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated-limit-4-hours';
-			new ODate(mockDateElement);
+			const fakeNow = new Date();
+			const fiveHoursAgo = new Date(fakeNow);
+
+			fiveHoursAgo.setHours(fakeNow.getHours() - 5);
+			clock = sinon.useFakeTimers(fakeNow);
+
+			fiveHoursAgoDateTime = ftDateFormat.format(fiveHoursAgo, 'datetime');
+
+			sandbox = document.createElement('div');
+			sandbox.innerHTML = `<time data-o-component="o-date" datetime="${fiveHoursAgo.toISOString()}" class="o-date"></time>`;
+			mockDateElement = sandbox.querySelector('[data-o-component="o-date"]');
 		});
 
-		it('renders the date in the element', () => {
-			proclaim.equal(mockDateElement.innerHTML, '11m ago');
+		afterEach(() => {
+			clock.restore();
+			sandbox = null;
+			mockDateElement = null;
 		});
 
-		it('adds a the aria label with a non-abbreviated unit', () => {
-			proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+		describe('time-ago-limit-4-hours', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.odateformat = 'time-ago-limit-4-hours';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
+			});
+
+			it('adds an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), '5 hours ago');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), fiveHoursAgoDateTime);
+			});
 		});
+
+		describe('time-ago-abbreviated', () => {
+
+			beforeEach(() => {
+				mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '5h ago');
+			});
+
+			it('adds an aria-label attribute with a non-abbreviated unit', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), '5 hours ago');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), fiveHoursAgoDateTime);
+			});
+		});
+
+		describe('time-ago-abbreviated-limit-4-hours', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated-limit-4-hours';
+				new ODate(mockDateElement);
+			});
+
+			it('renders nothing in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '');
+			});
+
+			it('removes the aria-label attribute', () => {
+				proclaim.isNull(mockDateElement.getAttribute('aria-label'));
+			});
+
+			it('removes the title attribute', () => {
+				proclaim.isNull(mockDateElement.getAttribute('title'));
+			});
+
+			it('adds an aria-hidden attribute', () => {
+				proclaim.strictEqual(mockDateElement.getAttribute('aria-hidden'), '');
+			});
+		});
+
+		describe('today-or-yesterday-or-nothing', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.oDateFormat = 'today-or-yesterday-or-nothing';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, 'today');
+			});
+
+			it('adds an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), 'today');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), fiveHoursAgoDateTime);
+			});
+		});
+
+		describe('date-only', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.odateformat = 'date-only';
+				new ODate(mockDateElement);
+			});
+
+			it('renders the date in the element', () => {
+				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
+			});
+
+			it('adds an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), '5 hours ago');
+			});
+
+			it('adds a title attribute containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), fiveHoursAgoDateTime);
+			});
+		});
+
 	});
 
-	describe('today-or-yesterday-or-nothing', () => {
-		beforeEach(() => {
-			mockDateElement.dataset.oDateFormat = 'today-or-yesterday-or-nothing';
-			new ODate(mockDateElement);
-		});
-
-		it('renders the date in the element', () => {
-			proclaim.equal(mockDateElement.innerHTML, 'today');
-		});
-	});
-
-	describe('date-only', () => {
-		beforeEach(() => {
-			mockDateElement.dataset.odateformat = 'date-only';
-			new ODate(mockDateElement);
-		});
-
-		it('renders the date in the element', () => {
-			proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
-		});
-	});
-
-	describe('time-ago-no-seconds', () => {
-		beforeEach(() => {
-			mockDateElement.dataset.odateformat = 'time-ago-no-seconds';
-			new ODate(mockDateElement);
-		});
-
-		it('renders the date in the element', () => {
-			proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
-		});
-	});
 });


### PR DESCRIPTION
When the requested date format returns an empty string, the `time`
element is not visible because it has no content. However a screen
reader (we tested using VoiceOver) will still read the date because the
`time` element has a `title` attribute.

We think that the experience for a person using assistive tech should be
as close as possible to the experience of a person who isn't. This PR
ensures that if the date string is empty, the `aria-label` and `title`
attributes are not set. We also add an `aria-hidden` attribute to make
sure that the element is ignored.

This fixes #105.