### PR TITLE
Stop using magic webpack imports

### DIFF
--- a/test/date.test.js
+++ b/test/date.test.js
@@ -1,8 +1,7 @@
 /* eslint-env mocha */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* global proclaim, sinon */
 
-const oDate = require('../main');
+import oDate from '../main';
 
 describe('o-date', () => {
 

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -1,6 +1,5 @@
 /* eslint-env mocha */
-import proclaim from 'proclaim';
-import sinon from 'sinon/pkg/sinon';
+/* global proclaim, sinon */
 
 const ODate = require('../main');
 const ftDateFormat = require('ft-date-format');


### PR DESCRIPTION
Stop using the magic imports for proclaim and sinon and pull them from the global because that's where Karma has added them. This is required for obt v10 to be released.