### PR TITLE
Enable multiple formats within one `time` element

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ By default `o-date` will replace the contents of the `time` element with the for
 For example to include "updated at" copy within the `time` element followed by an abbreviated relative time:
 
 ```html
-<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-abbreviated"
-	datetime="2020-07-18T19:01:05.033Z" data-o-date-format="time-ago-abbreviated">
+<time data-o-component="o-date" class="o-date" datetime="2020-07-18T19:01:05.033Z" data-o-date-format="time-ago-abbreviated">
 	<!-- some arbitrary content -->
 	<span>updated at</span>
 	<!-- show the abbreviated time ago here in the printed element -->

--- a/README.md
+++ b/README.md
@@ -43,22 +43,37 @@ Set the `data-o-date-format` attribute to customise how the `time` element is pr
 
 ### Copy Options
 
-By default `o-date` will replace the contents of the `time` element with the formatted date. To include extra content alongside the formatted date add an element with the `o-date__printer` class. `o-date` will output the formatted date within the `o-date__printer` element and will not change other child elements.
+By default `o-date` will replace the contents of the `time` element with the formatted date. To include extra content alongside the formatted date add an element with the `data-o-date-printer` attribute. `o-date` will output the formatted date within the `data-o-date-printer` element and will not change other child elements.
 
-For example to show a relative time followed by the actual time:
+For example to include "update at" copy within the `time` element followed by an abbreviated relative time:
 
 ```html
 <time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-abbreviated" datetime="2020-07-18T19:01:05.033Z" data-o-date-format="time-ago-abbreviated">
-    <span class="o-date__printer">
-			<!-- show the abbreviated time ago here -->
-			<!-- fallback to the date if o-date JavaScript fails  -->
+		<!-- some arbitrary content -->
+    <span>updated at</span>
+		<!-- show the abbreviated time ago here in the printed element -->
+		<!-- fallback to the date if o-date JavaScript fails  -->
+    <span data-o-date-printer>
       20 July 2020
 		</span>
-		<!-- always include the exact time -->
-    <span>14:36</span>
 </time>
-
 ```
+
+Render a date multiple times within the same `o-date` component by including multiple `data-o-date-printer` elements. Each printer element may have a unique format by adding the `data-o-date-format` attribute. If `data-o-date-format` is not set on the printer element the parent `data-o-date-format` element will be used:
+
+```html
+<time data-o-component="o-date" class="o-date" datetime="2020-07-18T19:01:05.033Z" data-o-date-format="date-only" >
+	<!-- render the date in the "date-only" format here -->
+	<!-- (as set on the parent "time" element) -->
+  <span data-o-date-printer></span>
+  <!-- render the date in the "time-ago-abbreviated" format here -->
+	<span data-o-date-printer data-o-date-format="time-ago-abbreviated"></span>
+	<!-- render the date in the custom format "h:mm" here -->
+	<span data-o-date-printer data-o-date-format="h:mm"></span>
+</time>
+```
+
+_Previously a CSS class `o-date__printer` was used instead of the `data-o-date-printer` attribute. The class `o-date__printer` is now deprecated._
 
 ## JavaScript
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _The rendered date will be a relative time or timestamp for a given date, in acc
 We recommend a human readable date is added to the `time` element to support a [core experience](https://origami.ft.com/docs/components/compatibility/#core--enhanced-experiences) without JavaScript:
 ```html
 <time data-o-component="o-date" class="o-date" datetime="2000-06-14T23:00:00.000Z">
-  June 15 2000
+	June 15 2000
 </time>
 ```
 _Node.js applications could provide a core experience fallback using the [Financial-Times/ft-date-format](https://github.com/Financial-Times/ft-date-format) library._
@@ -48,25 +48,26 @@ By default `o-date` will replace the contents of the `time` element with the for
 For example to include "update at" copy within the `time` element followed by an abbreviated relative time:
 
 ```html
-<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-abbreviated" datetime="2020-07-18T19:01:05.033Z" data-o-date-format="time-ago-abbreviated">
-		<!-- some arbitrary content -->
-    <span>updated at</span>
-		<!-- show the abbreviated time ago here in the printed element -->
-		<!-- fallback to the date if o-date JavaScript fails  -->
-    <span data-o-date-printer>
-      20 July 2020
-		</span>
+<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-abbreviated"
+	datetime="2020-07-18T19:01:05.033Z" data-o-date-format="time-ago-abbreviated">
+	<!-- some arbitrary content -->
+	<span>updated at</span>
+	<!-- show the abbreviated time ago here in the printed element -->
+	<!-- fallback to the date if o-date JavaScript fails  -->
+	<span data-o-date-printer>
+		20 July 2020
+	</span>
 </time>
 ```
 
 Render a date multiple times within the same `o-date` component by including multiple `data-o-date-printer` elements. Each printer element may have a unique format by adding the `data-o-date-format` attribute. If `data-o-date-format` is not set on the printer element the parent `data-o-date-format` element will be used:
 
 ```html
-<time data-o-component="o-date" class="o-date" datetime="2020-07-18T19:01:05.033Z" data-o-date-format="date-only" >
+<time data-o-component="o-date" class="o-date" datetime="2020-07-18T19:01:05.033Z" data-o-date-format="date-only">
 	<!-- render the date in the "date-only" format here -->
 	<!-- (as set on the parent "time" element) -->
-  <span data-o-date-printer></span>
-  <!-- render the date in the "time-ago-abbreviated" format here -->
+	<span data-o-date-printer></span>
+	<!-- render the date in the "time-ago-abbreviated" format here -->
 	<span data-o-date-printer data-o-date-format="time-ago-abbreviated"></span>
 	<!-- render the date in the custom format "h:mm" here -->
 	<span data-o-date-printer data-o-date-format="h:mm"></span>
@@ -97,7 +98,7 @@ Or dispatch the `o.DOMContentLoaded` event to auto-construct all Origami compone
 ```js
 import 'o-date';
 document.addEventListener('DOMContentLoaded', function() {
-    document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
+	document.dispatchEvent(new CustomEvent('o.DOMContentLoaded'));
 });
 ```
 

--- a/demos/src/declarative.mustache
+++ b/demos/src/declarative.mustache
@@ -1,3 +1,13 @@
+<time data-o-component="o-date" class="o-date" datetime="2000-06-14T23:00:00.000Z">June 15, 2000</time> (dates far in the past are formatted as exact dates)
+<br>
+<time data-o-component="o-date" class="o-date"></time> (more recent dates are formatted as relative times)
+<br>
+<time data-o-component="o-date" class="o-date" data-o-date-format="today-or-yesterday-or-nothing"></time> (Using the o-date-format option)
+<br>
+<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-limit-4-hours"></time> (Using the o-date-format with time-ago-limit-4-hours)
+<br>
+<time data-o-component="o-date" class="o-date" data-o-date-format="h:mm a"></time> (Using the o-date-format with custom format string)
+<br>
 <time data-o-component="o-date" class="o-date" data-o-date-format="date-only">
 	<!-- render date-only here, set on the parent "time" element -->
 	<span data-o-date-printer>
@@ -8,14 +18,4 @@
 	<!-- render a custom format here, the absolute time -->
 	<span data-o-date-printer data-o-date-format="h:mm">
 	</span>
-</time>
-<br>
-<time data-o-component="o-date" class="o-date" datetime="2000-06-14T23:00:00.000Z">June 15, 2000</time> (dates far in the past are formatted as exact dates)
-<br>
-<time data-o-component="o-date" class="o-date"></time> (more recent dates are formatted as relative times)
-<br>
-<time data-o-component="o-date" class="o-date" data-o-date-format="today-or-yesterday-or-nothing"></time> (Using the o-date-format option)
-<br>
-<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-limit-4-hours"></time> (Using the o-date-format with time-ago-limit-4-hours)
-<br>
-<time data-o-component="o-date" class="o-date" data-o-date-format="h:mm a"></time> (Using the o-date-format with custom format string)
+</time> (Using multiple o-date-format elements)

--- a/demos/src/declarative.mustache
+++ b/demos/src/declarative.mustache
@@ -1,3 +1,15 @@
+<time data-o-component="o-date" class="o-date" data-o-date-format="date-only">
+	<!-- render date-only here, set on the parent "time" element -->
+	<span data-o-date-printer>
+	</span>
+	<!-- render an abbreviated, relative time ago here -->
+	<span data-o-date-printer data-o-date-format="time-ago-abbreviated">
+	</span>
+	<!-- render a custom format here, the absolute time -->
+	<span data-o-date-printer data-o-date-format="h:mm">
+	</span>
+</time>
+<br>
 <time data-o-component="o-date" class="o-date" datetime="2000-06-14T23:00:00.000Z">June 15, 2000</time> (dates far in the past are formatted as exact dates)
 <br>
 <time data-o-component="o-date" class="o-date"></time> (more recent dates are formatted as relative times)

--- a/src/js/date.js
+++ b/src/js/date.js
@@ -4,6 +4,7 @@ const updateEventName = 'update';
 let interval;
 
 function ftDateFormatWarning(methodName) {
+	// eslint-disable-next-line no-console
 	console.warn(`The o-date method "${methodName}" is deprecated. Use the "ft-date-format" package instead or contact the Origami team for help: https://github.com/Financial-Times/ft-date-format`);
 }
 
@@ -16,12 +17,14 @@ class ODate {
 	constructor(rootEl) {
 
 		if (!rootEl) {
+			// eslint-disable-next-line no-console
 			console.warn('To initialise all o-date elements on the page use ' +
 				'the `init` method. Passing no arguments to the constructor ' +
 				'is deprecated.');
 		}
 
 		if (rootEl && !(rootEl instanceof HTMLElement)) {
+			// eslint-disable-next-line no-console
 			console.warn('Using the constructor to initialise one or more ' +
 				'o-date elements with a query selector is deprecated. ' +
 				'Pass a single o-date HTMLElement to initialise or use the ' +
@@ -63,6 +66,7 @@ class ODate {
 
 	/**
 	 * Re-render the formatted date within the `time` element.
+	 * @returns {undefined}
 	 */
 	update() {
 		const el = this.el;
@@ -106,6 +110,7 @@ class ODate {
 	/**
 	 * Remove o-date from the `time` element i.e. remove event
 	 * listeners and drop references to the element.
+	 * @returns {undefined}
 	 */
 	destroy() {
 		document.body.removeEventListener(updateEventName, this);
@@ -114,7 +119,7 @@ class ODate {
 
 	/**
 	 * Initialise the o-date component.
-	 * @param {HTMLElement|String} rootElement - The root element or CSS selector to initialise
+	 * @param {HTMLElement|String} el - The root element or CSS selector to initialise
 	 * @returns {Array<ODate> | ODate} - An o-date instance or array of o-date instances.
 	 */
 	static init (el) {
@@ -139,8 +144,9 @@ class ODate {
 
 	/**
 	 * Render the date to the "printer" element in the requested format.
-	 * @param {HTMLElement} printer
-	 * @param {Date} date
+	 * @param {HTMLElement} printer - The element to render the date in
+	 * @param {Date} date - The date to format
+	 * @returns {undefined}
 	 */
 	_renderDateFor(printer, date) {
 		// Use the printer `data-o-date-format` if found or fallback to the
@@ -192,6 +198,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static toDate() {
 		ftDateFormatWarning('toDate');
@@ -200,6 +207,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static format() {
 		ftDateFormatWarning('format');
@@ -208,6 +216,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static getSecondsBetween() {
 		ftDateFormatWarning('getSecondsBetween');
@@ -216,6 +225,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static ftTime() {
 		ftDateFormatWarning('ftTime');
@@ -224,6 +234,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static isNearFuture() {
 		ftDateFormatWarning('isNearFuture');
@@ -232,6 +243,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static isFarFuture() {
 		ftDateFormatWarning('isFarFuture');
@@ -240,6 +252,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static isToday() {
 		ftDateFormatWarning('isToday');
@@ -248,6 +261,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static isYesterday() {
 		ftDateFormatWarning('isYesterday');
@@ -256,6 +270,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static timeAgo() {
 		ftDateFormatWarning('timeAgo');
@@ -264,6 +279,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static asTodayOrYesterdayOrNothing() {
 		ftDateFormatWarning('asTodayOrYesterdayOrNothing');
@@ -272,6 +288,7 @@ class ODate {
 
 	/**
 	 * @deprecated Use [ft-date-format]{@link https://github.com/Financial-Times/ft-date-format} instead.
+	 * @return {String} - A formatted date or empty string.
 	 */
 	static timeAgoNoSeconds() {
 		ftDateFormatWarning('timeAgoNoSeconds');

--- a/src/js/date.js
+++ b/src/js/date.js
@@ -16,7 +16,7 @@ class ODate {
 	constructor(rootEl) {
 
 		if (!rootEl) {
-			console.warn('To initalise all o-date elements on the page use ' +
+			console.warn('To initialise all o-date elements on the page use ' +
 				'the `init` method. Passing no arguments to the constructor ' +
 				'is deprecated.');
 		}
@@ -24,7 +24,7 @@ class ODate {
 		if (rootEl && !(rootEl instanceof HTMLElement)) {
 			console.warn('Using the constructor to initialise one or more ' +
 				'o-date elements with a query selector is deprecated. ' +
-				'Pass a single o-date HTMLElement to initalise or use the ' +
+				'Pass a single o-date HTMLElement to initialise or use the ' +
 				'`init` method.');
 		}
 

--- a/src/js/date.js
+++ b/src/js/date.js
@@ -40,14 +40,14 @@ class ODate {
 			this.el = rootEl.querySelector('[data-o-component~="o-date"]');
 		}
 
-		if (this.el !== undefined) {
+		if (this.el) {
 			document.body.addEventListener(updateEventName, this);
 
 			this.update();
 			this.el.setAttribute('data-o-date-js', '');
 		}
 
-		if (this.el !== undefined && !interval) {
+		if (this.el && !interval) {
 			interval = setInterval(function () {
 				document.body.dispatchEvent(new CustomEvent(updateEventName));
 			}, 60000);

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -50,9 +50,9 @@ describe('o-date DOM', () => {
 			});
 
 			it('renders all dates in the element', () => {
-				proclaim.contains(mockDateElement.textContent, '11 minutes ago');
-				proclaim.contains(mockDateElement.textContent, '1m ago');
-				proclaim.contains(mockDateElement.textContent, '2:55');
+				proclaim.include(mockDateElement.textContent, '11 minutes ago');
+				proclaim.include(mockDateElement.textContent, '1m ago');
+				proclaim.include(mockDateElement.textContent, '2:55');
 			});
 
 			it('adds an aria-label attribute containing the ultimate date', () => {

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -12,7 +12,6 @@ describe('o-date DOM', () => {
 	describe('11 minutes ago', () => {
 		let elevenMinutesAgo;
 		let elevenMinutesAgoDateTime;
-		let elevenMinutesAgoCustomFormat;
 
 		beforeEach(() => {
 			const fakeNow = new Date();

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -10,11 +10,13 @@ describe('o-date DOM', () => {
 	let mockDateElement;
 
 	describe('11 minutes ago', () => {
+		let elevenMinutesAgo;
 		let elevenMinutesAgoDateTime;
+		let elevenMinutesAgoCustomFormat;
 
 		beforeEach(() => {
 			const fakeNow = new Date();
-			const elevenMinutesAgo = new Date(fakeNow);
+			elevenMinutesAgo = new Date(fakeNow);
 
 			elevenMinutesAgo.setMinutes(fakeNow.getMinutes() - 11);
 			clock = sinon.useFakeTimers(fakeNow);
@@ -33,7 +35,11 @@ describe('o-date DOM', () => {
 		});
 
 		describe('multiple prints with multiple formats', () => {
+			let elevenMinutesAgoCustomFormat;
 			beforeEach(() => {
+				const customFormat = 'h:mm';
+				elevenMinutesAgoCustomFormat = ftDateFormat.format(elevenMinutesAgo, customFormat);
+
 				mockDateElement.dataset.odateformat = 'date-only';
 				mockDateElement.innerHTML = `
 					<!-- render date-only here, set on the parent "time" element -->
@@ -43,7 +49,7 @@ describe('o-date DOM', () => {
 					<span data-o-date-printer data-o-date-format="time-ago-abbreviated">
 					</span>
 					<!-- render a custom format here, the absolute time -->
-					<span data-o-date-printer data-o-date-format="h:mm">
+					<span data-o-date-printer data-o-date-format="${customFormat}">
 					</span>
 				`;
 				new ODate(mockDateElement);
@@ -51,8 +57,8 @@ describe('o-date DOM', () => {
 
 			it('renders all dates in the element', () => {
 				proclaim.include(mockDateElement.textContent, '11 minutes ago');
-				proclaim.include(mockDateElement.textContent, '1m ago');
-				proclaim.include(mockDateElement.textContent, '2:55');
+				proclaim.include(mockDateElement.textContent, '11m ago');
+				proclaim.include(mockDateElement.textContent, elevenMinutesAgoCustomFormat);
 			});
 
 			it('adds an aria-label attribute containing the ultimate date', () => {

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -32,6 +32,39 @@ describe('o-date DOM', () => {
 			mockDateElement = null;
 		});
 
+		describe('multiple prints with multiple formats', () => {
+			beforeEach(() => {
+				mockDateElement.dataset.odateformat = 'date-only';
+				mockDateElement.innerHTML = `
+					<!-- render date-only here, set on the parent "time" element -->
+					<span data-o-date-printer>
+					</span>
+					<!-- render an abbreviated, relative time ago here -->
+					<span data-o-date-printer data-o-date-format="time-ago-abbreviated">
+					</span>
+					<!-- render a custom format here, the absolute time -->
+					<span data-o-date-printer data-o-date-format="h:mm">
+					</span>
+				`;
+				new ODate(mockDateElement);
+			});
+
+			it('renders all dates in the element', () => {
+				proclaim.contains(mockDateElement.textContent, '11 minutes ago');
+				proclaim.contains(mockDateElement.textContent, '1m ago');
+				proclaim.contains(mockDateElement.textContent, '2:55');
+			});
+
+			it('adds an aria-label attribute containing the ultimate date', () => {
+				const abbreviatedPrinter = mockDateElement.querySelector('[data-o-date-format="time-ago-abbreviated"]');
+				proclaim.equal(abbreviatedPrinter.getAttribute('aria-label'), '11 minutes ago');
+			});
+
+			it('adds a title attribute to all printers containing the full date', () => {
+				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
+			});
+		});
+
 		describe('time-ago-limit-4-hours', () => {
 			beforeEach(() => {
 				mockDateElement.dataset.odateformat = 'time-ago-limit-4-hours';
@@ -229,7 +262,7 @@ describe('o-date DOM', () => {
 			});
 
 			it('adds an aria-hidden attribute', () => {
-				proclaim.strictEqual(mockDateElement.getAttribute('aria-hidden'), '');
+				proclaim.equal(mockDateElement.getAttribute('aria-hidden'), 'true');
 			});
 		});
 


### PR DESCRIPTION
As part of this work:

- Deprecate the `o-date__printer` class in favour of
the `data-o-date-printer` attribute.
- Allow multiple `data-o-date-printer` attributes
within one `o-date` component to support the output
of a formatted date multiple times.
- Allow `data-o-date-format` on any printer element
to support the output of multiple formats, including
relative times, within one `o-date` component.

#137