### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/demos/src/declarative.js
+++ b/demos/src/declarative.js
@@ -1,4 +1,4 @@
-import ODate from '../../main';
+import ODate from '../../main.js';
 
 const now = new Date();
 const today = new Date();

--- a/demos/src/imperative.js
+++ b/demos/src/imperative.js
@@ -1,4 +1,4 @@
-import ODate from '../../main';
+import ODate from '../../main.js';
 
 const times = document.querySelectorAll('[data-o-component="o-date"]');
 

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import oDate from './src/js/date';
+import oDate from './src/js/date.js';
 const constructAll = function () {
 	oDate.init();
 	document.removeEventListener('o.DOMContentLoaded', constructAll);

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim sinon */
-import * as fixtures from './helpers/fixtures';
-import oDate from '../main';
+import * as fixtures from './helpers/fixtures.js';
+import oDate from '../main.js';
 
 describe('o-date', () => {
 

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 /* global proclaim, sinon */
 
-import ODate from '../main';
+import ODate from '../main.js';
 import ftDateFormat from 'ft-date-format';
 
 describe('o-date DOM', () => {


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing