### PR TITLE
Do not merge: Remove aria-label use from the `time` element - new issues

### DIFF
--- a/demos/src/declarative.mustache
+++ b/demos/src/declarative.mustache
@@ -1,4 +1,4 @@
-<time data-o-component="o-date" class="o-date" datetime="2000-06-14T23:00:00.000Z">June 15, 2000</time> (dates far in the past are formatted as exact dates)
+<time data-o-component="o-date" class="o-date" datetime="2000-06-14T23:00:00.000Z">June 15 2000</time> (dates far in the past are formatted as exact dates)
 <br>
 <time data-o-component="o-date" class="o-date"></time> (more recent dates are formatted as relative times)
 <br>


### PR DESCRIPTION
As part of an accessibility audit our use of `aria-label` has been
flagged:
>Multiple time tags could be located that contained the data that
>the articles appeared on page; however, upon inspecting these
>elements an aria-label can be located. This aria-label is unable
>to be announced as the html tag provided does not support
>aria-label.

It's not clear if that is a problem or an observation of something
seemingly redundant. The recommendation is to remove:
>We would recommend removing the aria-label from the time tag as it serves no purpose, as the visible text provided is clear enough.

However `o-date` labels were added to by Customer Products based
on a previous accessibility audit:
https://github.com/Financial-Times/o-date/pull/102

They were added to announce an abbreviated time differently, e.g.
‘6h’ as ‘6 hours’. In the specific case highlighted the labels
match the actual text and can be removed. However if we remove the
labels completely we undo the work from the previous audit re.
abbreviated names.

This PR attempts to address that by:
1. Only adding an alternative for screen readers if it would
actually be different to the existing text.
2. Adding a visually hidden alternative to abbreviated times within
the `time` element, in a nessted `span`, and using `aria-hidden`
to hide the abbreviation from screen readers.

It appears that VoiceOver on MacOS in Safari may read the hidden
abbreviation regardless, so this should not be released.

I found VoiceOver to read the `aria-hidden` span when using
the down arrow key to read lines in the "declarative" demo, but
not when holding the VO command (?,ctrl,alt) and navigating each
element with the left/right arrows.

It may be safest for now to undo this work and remove the
`aria-label` when there is no alternative for screen readers but
keep it when there is.
https://github.com/Financial-Times/o-date/blob/809e0c26722e0ea5f9f4bb1fede65ee45d7f0ad3/src/js/date.js#L195