### PR TITLE
Only apply an `aria-label` when it differs to the text in `time`.

### DIFF
--- a/demos/src/declarative.mustache
+++ b/demos/src/declarative.mustache
@@ -2,6 +2,8 @@
 <br>
 <time data-o-component="o-date" class="o-date"></time> (more recent dates are formatted as relative times)
 <br>
+<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-abbreviated"></time> (a recent date using the o-date-format with time-ago-abbreviated)
+<br>
 <time data-o-component="o-date" class="o-date" data-o-date-format="today-or-yesterday-or-nothing"></time> (Using the o-date-format option)
 <br>
 <time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-limit-4-hours"></time> (Using the o-date-format with time-ago-limit-4-hours)

--- a/src/js/date.js
+++ b/src/js/date.js
@@ -191,8 +191,8 @@ class ODate {
 			printer.innerHTML = dateString;
 		}
 
-		if (dateString) {
-			printer.setAttribute('aria-label', labelString || dateString);
+		if (dateString && labelString) {
+			printer.setAttribute('aria-label', labelString);
 		} else {
 			printer.removeAttribute('aria-label');
 		}

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -80,8 +80,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -99,8 +99,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -157,8 +157,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, 'today');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), 'today');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -176,8 +176,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -195,8 +195,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -238,8 +238,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '5 hours ago');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -257,8 +257,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '5 hours ago');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -319,8 +319,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, 'today');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), 'today');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -338,8 +338,8 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
 			});
 
-			it('adds an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '5 hours ago');
+			it('does not add an aria-label attribute containing the same date', () => {
+				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {


### PR DESCRIPTION
Relates to:
https://financialtimes.atlassian.net/browse/CON-1122?focusedCommentId=531261

As part of an accessibility audit our use of `aria-label` has been
flagged:
>Multiple time tags could be located that contained the data that
>the articles appeared on page; however, upon inspecting these
>elements an aria-label can be located. This aria-label is unable
>to be announced as the html tag provided does not support
>aria-label.

It's not clear if that is a problem or an observation of something
seemingly redundant. The recommendation is to remove:
>We would recommend removing the aria-label from the time tag as
>it serves no purpose, as the visible text provided is clear enough.

However `o-date` labels were added to by Customer Products based
on a previous accessibility audit:
https://github.com/Financial-Times/o-date/pull/102

They were added to announce an abbreviated time differently, e.g.
‘6h’ as ‘6 hours’. In the specific case highlighted the labels
match the actual text and can be removed. However if we remove the
labels completely we undo the work from the previous audit re.
abbreviated names.

This PR is a middle ground which will remove the label in the
case flagged but keep it for abbreviated dates.

This is incomplete, and needs work. I found VoiceOver to read the
abbreviated date when using the down arrow key to read lines in
the "declarative" demo, but not when holding the VO command
(?,ctrl,alt) and navigating each element with the left/right arrows
(in which case it would read the label for the time element
"6 hours" and announce a group, which I could step into to read the
abbreviated time "6h").

This PR attempts to solve the problem by using a visually hidden
`span` instead of an `aria-label`, but has other problems:
https://github.com/Financial-Times/o-date/pull/173

More research/guidance is needed. I have no idea how other screen
readers handle either approach.