### PR TITLE
backport: o-date, deprecate abbreviated time options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,22 +42,22 @@ Set the `data-o-date-format` attribute to customise how the `time` element is pr
 - `time-ago-no-seconds`: always display a relative time but if the relative time is under a minute display "Less than a minute ago" (e.g. `Less than a minute ago`, `10 minutes ago`, `an hour ago`, `4 hours ago`).
 - `time-ago-limit-4-hours`: always display a relative time but hide the `time` element if the `datetime` is older than 4 hours (e.g. `4 seconds ago`, `10 minutes ago`, `4 hours ago`).
 - `time-ago-limit-24-hours`: always display a relative time but hide the `time` element if the `datetime` is older than 24 hours (e.g. `4 seconds ago`, `10 minutes ago`, `10 hours ago`).
-- `time-ago-abbreviated`: always display a relative time with units abbreviated (e.g. `4s ago`, `10m ago`, `1h ago`).
-- `time-ago-abbreviated-limit-4-hours`: hide the `time` element when the `datetime` is older than 4 hours, otherwise render the same as `time-ago-abbreviated`.
 - `today-or-yesterday-or-nothing`: display `today` if the `datetime` is today, `yesterday` if it was yesterday, or hide the `time` element if the `datetime` is older than yesterday.
 - [custom format](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html): it is recommended to use a standard FT format but a [custom format](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) may be used e.g. `h:mm a`.
+
+Note: There used to be `time-ago-abbreviated` and `time-ago-abbreviated-limit-4-hours` options which are now both deprecated. These options still work but no longer show an abbreviated date. They will be removed in a future major version.
 
 ### Copy Options
 
 By default `o-date` will replace the contents of the `time` element with the formatted date. To include extra content alongside the formatted date add an element with the `data-o-date-printer` attribute. `o-date` will output the formatted date within the `data-o-date-printer` element and will not change other child elements.
 
-For example to include "updated at" copy within the `time` element followed by an abbreviated relative time:
+For example to include "updated at" copy within the `time` element followed by a relative time:
 
 ```html
-<time data-o-component="o-date" class="o-date" datetime="2020-07-18T19:01:05.033Z" data-o-date-format="time-ago-abbreviated">
+<time data-o-component="o-date" class="o-date" datetime="2020-07-18T19:01:05.033Z" data-o-date-format="time-ago-limit-4-hours">
 	<!-- some arbitrary content -->
 	<span>updated at</span>
-	<!-- show the abbreviated time ago here in the printed element -->
+	<!-- show the time ago here in the printed element -->
 	<!-- fallback to the date if o-date JavaScript fails  -->
 	<span data-o-date-printer>
 		20 July 2020
@@ -72,8 +72,8 @@ Render a date multiple times within the same `o-date` component by including mul
 	<!-- render the date in the "date-only" format here -->
 	<!-- (as set on the parent "time" element) -->
 	<span data-o-date-printer></span>
-	<!-- render the date in the "time-ago-abbreviated" format here -->
-	<span data-o-date-printer data-o-date-format="time-ago-abbreviated"></span>
+	<!-- render the date in the "time-ago-limit-4-hours" format here -->
+	<span data-o-date-printer data-o-date-format="time-ago-limit-4-hours"></span>
 	<!-- render the date in the custom format "h:mm" here -->
 	<span data-o-date-printer data-o-date-format="h:mm"></span>
 </time>

--- a/demos/src/declarative.mustache
+++ b/demos/src/declarative.mustache
@@ -2,8 +2,6 @@
 <br>
 <time data-o-component="o-date" class="o-date"></time> (more recent dates are formatted as relative times)
 <br>
-<time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-abbreviated"></time> (a recent date using the o-date-format with time-ago-abbreviated)
-<br>
 <time data-o-component="o-date" class="o-date" data-o-date-format="today-or-yesterday-or-nothing"></time> (Using the o-date-format option)
 <br>
 <time data-o-component="o-date" class="o-date" data-o-date-format="time-ago-limit-4-hours"></time> (Using the o-date-format with time-ago-limit-4-hours)
@@ -16,8 +14,8 @@
 	<!-- render date-only here, set on the parent "time" element -->
 	<span data-o-date-printer>
 	</span>
-	<!-- render an abbreviated, relative time ago here -->
-	<span data-o-date-printer data-o-date-format="time-ago-abbreviated">
+	<!-- render a relative time ago here -->
+	<span data-o-date-printer data-o-date-format="time-ago-limit-4-hours">
 	</span>
 	<!-- render a custom format here, the absolute time -->
 	<span data-o-date-printer data-o-date-format="h:mm">

--- a/src/js/date.js
+++ b/src/js/date.js
@@ -154,29 +154,28 @@ class ODate {
 		const format = printer.getAttribute('data-o-date-format') ||
 			this.el.getAttribute('data-o-date-format');
 
-		let dateString;
-		let labelString;
+		let formattedDate;
 
 		if (format === 'today-or-yesterday-or-nothing') {
-			dateString = ftDateFormat.asTodayOrYesterdayOrNothing(date);
+			formattedDate = ftDateFormat.asTodayOrYesterdayOrNothing(date);
 		} else if (format === 'date-only') {
-			dateString = ftDateFormat.format(date, 'date');
+			formattedDate = ftDateFormat.format(date, 'date');
 		} else if (format === 'time-ago-limit-4-hours') {
-			dateString = ftDateFormat.timeAgo(date, { limit: 4 * ftDateFormat.inSeconds.hour });
+			formattedDate = ftDateFormat.timeAgo(date, { limit: 4 * ftDateFormat.inSeconds.hour });
 		} else if (format === 'time-ago-limit-24-hours') {
-			dateString = ftDateFormat.timeAgo(date, { limit: 24 * ftDateFormat.inSeconds.hour });
+			formattedDate = ftDateFormat.timeAgo(date, { limit: 24 * ftDateFormat.inSeconds.hour });
 		} else if (format === 'time-ago-abbreviated') {
-			dateString = ftDateFormat.timeAgo(date, { abbreviated: true });
-			labelString = ftDateFormat.timeAgo(date);
+			console.warn('The o-date format "time-ago-abbreviated" is deprecated and the time is no longer abbreviated. Consider using "time-ago-limit-4-hours" instead.');
+			formattedDate = ftDateFormat.timeAgo(date);
 		} else if (format === 'time-ago-abbreviated-limit-4-hours') {
-			dateString = ftDateFormat.timeAgo(date, { abbreviated: true, limit: 4 * ftDateFormat.inSeconds.hour });
-			labelString = ftDateFormat.timeAgo(date, { limit: 4 * ftDateFormat.inSeconds.hour });
+			console.warn('The o-date format "time-ago-abbreviated-limit-4-hours" is deprecated and the time is no longer abbreviated. Use "time-ago-limit-4-hours" instead.');
+			formattedDate = ftDateFormat.timeAgo(date, { limit: 4 * ftDateFormat.inSeconds.hour });
 		} else if (format === 'time-ago-no-seconds') {
-			dateString = ftDateFormat.timeAgoNoSeconds(date);
+			formattedDate = ftDateFormat.timeAgoNoSeconds(date);
 		} else if (format !== null) {
-			dateString = ftDateFormat.format(date, format);
+			formattedDate = ftDateFormat.format(date, format);
 		} else {
-			dateString = ftDateFormat.ftTime(date);
+			formattedDate = ftDateFormat.ftTime(date);
 		}
 
 		// To avoid triggering a parent live region unnecessarily
@@ -186,15 +185,9 @@ class ODate {
 			printer.firstChild.nodeType === 3;
 
 		if (hasSingleTextNode) {
-			printer.firstChild.nodeValue = dateString;
+			printer.firstChild.nodeValue = formattedDate;
 		} else {
-			printer.innerHTML = dateString;
-		}
-
-		if (dateString && labelString) {
-			printer.setAttribute('aria-label', labelString);
-		} else {
-			printer.removeAttribute('aria-label');
+			printer.innerHTML = formattedDate;
 		}
 	}
 

--- a/test/date.test.js
+++ b/test/date.test.js
@@ -425,19 +425,19 @@ describe('o-date', () => {
 			}
 		});
 
-		it('returns abbreviations if the abbreviated option is provided', () => {
+		it('returns no abbreviation if the abbreviated option is provided (abbreviation is deprecated)', () => {
 			const abbreviations = {
-				'2s ago': 2 * inSeconds.second,
-				'1m ago': inSeconds.minute,
-				'2m ago': 90 * inSeconds.second,
-				'1h ago': inSeconds.hour,
-				'2h ago': 90 * inSeconds.minute,
-				'1d ago': 22 * inSeconds.hour,
-				'2d ago': 36 * inSeconds.hour,
-				'1mth ago': 25 * inSeconds.day,
-				'2mth ago': 45 * inSeconds.day,
-				'1y ago': 345 * inSeconds.day,
-				'2y ago': 547 * inSeconds.day
+				'2 seconds ago': 2 * inSeconds.second,
+				'1 minute ago': inSeconds.minute,
+				'2 minute ago': 90 * inSeconds.second,
+				'1 hour ago': inSeconds.hour,
+				'2 hour ago': 90 * inSeconds.minute,
+				'1 day ago': 22 * inSeconds.hour,
+				'2 day ago': 36 * inSeconds.hour,
+				'1 month ago': 25 * inSeconds.day,
+				'2 month ago': 45 * inSeconds.day,
+				'1 year ago': 345 * inSeconds.day,
+				'2 year ago': 547 * inSeconds.day
 			};
 
 			Object.keys(abbreviations).forEach(function (abbreviation) {

--- a/test/markup.test.js
+++ b/test/markup.test.js
@@ -44,9 +44,6 @@ describe('o-date DOM', () => {
 					<!-- render date-only here, set on the parent "time" element -->
 					<span data-o-date-printer>
 					</span>
-					<!-- render an abbreviated, relative time ago here -->
-					<span data-o-date-printer data-o-date-format="time-ago-abbreviated">
-					</span>
 					<!-- render a custom format here, the absolute time -->
 					<span data-o-date-printer data-o-date-format="${customFormat}">
 					</span>
@@ -56,13 +53,7 @@ describe('o-date DOM', () => {
 
 			it('renders all dates in the element', () => {
 				proclaim.include(mockDateElement.textContent, '11 minutes ago');
-				proclaim.include(mockDateElement.textContent, '11m ago');
 				proclaim.include(mockDateElement.textContent, elevenMinutesAgoCustomFormat);
-			});
-
-			it('adds an aria-label attribute containing the ultimate date', () => {
-				const abbreviatedPrinter = mockDateElement.querySelector('[data-o-date-format="time-ago-abbreviated"]');
-				proclaim.equal(abbreviatedPrinter.getAttribute('aria-label'), '11 minutes ago');
 			});
 
 			it('adds a title attribute to all printers containing the full date', () => {
@@ -80,10 +71,6 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
-			});
-
 			it('adds a title attribute containing the full date', () => {
 				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
 			});
@@ -99,28 +86,20 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
-			});
-
 			it('adds a title attribute containing the full date', () => {
 				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
 			});
 		});
 
-		describe('time-ago-abbreviated', () => {
+		describe('time-ago-abbreviated (deprecated)', () => {
 
 			beforeEach(() => {
 				mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated';
 				new ODate(mockDateElement);
 			});
 
-			it('renders the date in the element', () => {
-				proclaim.equal(mockDateElement.innerHTML, '11m ago');
-			});
-
-			it('adds an aria-label attribute with a non-abbreviated unit', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			it('renders the date in the element without abbreviation (abbreviation is deprecated)', () => {
+				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -128,18 +107,14 @@ describe('o-date DOM', () => {
 			});
 		});
 
-		describe('time-ago-abbreviated-limit-4-hours', () => {
+		describe('time-ago-abbreviated-limit-4-hours (deprecated)', () => {
 			beforeEach(() => {
 				mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated-limit-4-hours';
 				new ODate(mockDateElement);
 			});
 
-			it('renders the date in the element', () => {
-				proclaim.equal(mockDateElement.innerHTML, '11m ago');
-			});
-
-			it('adds an aria-label attribute with a non-abbreviated unit', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '11 minutes ago');
+			it('renders the date in the element without abbreviation (abbreviation is deprecated)', () => {
+				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -157,10 +132,6 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, 'today');
 			});
 
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
-			});
-
 			it('adds a title attribute containing the full date', () => {
 				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
 			});
@@ -176,10 +147,6 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
 			});
 
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
-			});
-
 			it('adds a title attribute containing the full date', () => {
 				proclaim.equal(mockDateElement.getAttribute('title'), elevenMinutesAgoDateTime);
 			});
@@ -193,10 +160,6 @@ describe('o-date DOM', () => {
 
 			it('renders the date in the element', () => {
 				proclaim.equal(mockDateElement.innerHTML, '11 minutes ago');
-			});
-
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -238,10 +201,6 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
 			});
 
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
-			});
-
 			it('adds a title attribute containing the full date', () => {
 				proclaim.equal(mockDateElement.getAttribute('title'), fiveHoursAgoDateTime);
 			});
@@ -257,28 +216,20 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
 			});
 
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
-			});
-
 			it('adds a title attribute containing the full date', () => {
 				proclaim.equal(mockDateElement.getAttribute('title'), fiveHoursAgoDateTime);
 			});
 		});
 
-		describe('time-ago-abbreviated', () => {
+		describe('time-ago-abbreviated (deprecated)', () => {
 
 			beforeEach(() => {
 				mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated';
 				new ODate(mockDateElement);
 			});
 
-			it('renders the date in the element', () => {
-				proclaim.equal(mockDateElement.innerHTML, '5h ago');
-			});
-
-			it('adds an aria-label attribute with a non-abbreviated unit', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), '5 hours ago');
+			it('renders the date in the element without abbreviation (abbreviation is deprecated)', () => {
+				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
 			});
 
 			it('adds a title attribute containing the full date', () => {
@@ -286,7 +237,7 @@ describe('o-date DOM', () => {
 			});
 		});
 
-		describe('time-ago-abbreviated-limit-4-hours', () => {
+		describe('time-ago-abbreviated-limit-4-hours (deprecated)', () => {
 			beforeEach(() => {
 				mockDateElement.dataset.oDateFormat = 'time-ago-abbreviated-limit-4-hours';
 				new ODate(mockDateElement);
@@ -294,10 +245,6 @@ describe('o-date DOM', () => {
 
 			it('renders nothing in the element', () => {
 				proclaim.equal(mockDateElement.innerHTML, '');
-			});
-
-			it('removes the aria-label attribute', () => {
-				proclaim.isNull(mockDateElement.getAttribute('aria-label'));
 			});
 
 			it('removes the title attribute', () => {
@@ -319,10 +266,6 @@ describe('o-date DOM', () => {
 				proclaim.equal(mockDateElement.innerHTML, 'today');
 			});
 
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
-			});
-
 			it('adds a title attribute containing the full date', () => {
 				proclaim.equal(mockDateElement.getAttribute('title'), fiveHoursAgoDateTime);
 			});
@@ -336,10 +279,6 @@ describe('o-date DOM', () => {
 
 			it('renders the date in the element', () => {
 				proclaim.equal(mockDateElement.innerHTML, '5 hours ago');
-			});
-
-			it('does not add an aria-label attribute containing the same date', () => {
-				proclaim.equal(mockDateElement.getAttribute('aria-label'), null);
 			});
 
 			it('adds a title attribute containing the full date', () => {


### PR DESCRIPTION
`time-ago-abbreviated` and `time-ago-abbreviated-limit-4-hours`
options are now both deprecated. These options still work but
no longer show an abbreviated date. They will be removed in a
future major version.

They were only used in one place and raised accessibility
concerns multiple times.

Closes: https://github.com/Financial-Times/origami/issues/203